### PR TITLE
fix: security audit findings in consensus-critical paths

### DIFF
--- a/x/ibc-hooks/ibc_module.go
+++ b/x/ibc-hooks/ibc_module.go
@@ -48,7 +48,7 @@ func (im IBCMiddleware) OnChanOpenInit(
 	if hook, ok := im.ICS4Middleware.Hooks.(OnChanOpenInitAfterHooks); ok {
 		hook.OnChanOpenInitAfterHook(ctx, order, connectionHops, portID, channelID, counterparty, version, finalVersion, err)
 	}
-	return version, err
+	return finalVersion, err
 }
 
 // OnChanOpenTry implements the IBCMiddleware interface

--- a/x/tokenization/approval_criteria/voting_challenges.go
+++ b/x/tokenization/approval_criteria/voting_challenges.go
@@ -76,9 +76,11 @@ func (c *VotingChallengesChecker) Check(ctx sdk.Context, approval *types.Collect
 		}
 
 		// Retrieve all votes for this proposal and calculate total yes weight
+		// Iterate over the original slice (not the map) for deterministic ordering
 		totalYesWeight := sdkmath.NewUint(0)
 		collectionId := collection.CollectionId
-		for voterAddress := range voterMap {
+		for _, voter := range challenge.Voters {
+			voterAddress := voter.Address
 			voteKey := c.votingService.ConstructVoteKey(collectionId, approverAddress, approvalLevel, approval.ApprovalId, proposalId, voterAddress)
 
 			vote, found := c.votingService.GetVoteFromStore(ctx, voteKey)
@@ -98,7 +100,7 @@ func (c *VotingChallengesChecker) Check(ctx sdk.Context, approval *types.Collect
 				}
 
 				// Calculate the yes weight contribution from this voter
-				voterWeight := voterMap[voterAddress]
+				voterWeight := voter.Weight
 				yesWeightPercent := vote.YesWeight
 				yesContribution := voterWeight.Mul(yesWeightPercent).Quo(sdkmath.NewUint(100))
 				totalYesWeight = totalYesWeight.Add(yesContribution)

--- a/x/tokenization/keeper/approved_transfers.go
+++ b/x/tokenization/keeper/approved_transfers.go
@@ -447,7 +447,9 @@ func (k Keeper) DeductAndGetUserApprovals(
 			if approvalCriteria != nil && len(approvalCriteria.VotingChallenges) > 0 {
 				for _, challenge := range approvalCriteria.VotingChallenges {
 					if challenge != nil && challenge.ResetAfterExecution {
-						_ = k.DeleteAllVotesForProposal(ctx, collection.CollectionId, approverAddress, approvalLevel, approval.ApprovalId, challenge.ProposalId, challenge.Voters)
+						if err := k.DeleteAllVotesForProposal(ctx, collection.CollectionId, approverAddress, approvalLevel, approval.ApprovalId, challenge.ProposalId, challenge.Voters); err != nil {
+							return nil, sdkerrors.Wrapf(err, "failed to reset votes after execution for proposal %s", challenge.ProposalId)
+						}
 					}
 				}
 			}

--- a/x/tokenization/keeper/icq_queries.go
+++ b/x/tokenization/keeper/icq_queries.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"strconv"
 	"strings"
 
 	sdkerrors "cosmossdk.io/errors"
@@ -319,7 +320,7 @@ func (k Keeper) EmitFullBalanceQueryResponseEvent(ctx sdk.Context, response *typ
 	if response.Error != "" {
 		attrs = append(attrs, sdk.NewAttribute(types.AttributeKeyError, response.Error))
 	} else {
-		attrs = append(attrs, sdk.NewAttribute("balance_store_size", string(rune(len(response.BalanceStore)))))
+		attrs = append(attrs, sdk.NewAttribute("balance_store_size", strconv.Itoa(len(response.BalanceStore))))
 	}
 
 	ctx.EventManager().EmitEvent(

--- a/x/tokenization/keeper/transfer_utils.go
+++ b/x/tokenization/keeper/transfer_utils.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	"github.com/bitbadges/bitbadgeschain/x/tokenization/types"
 
@@ -39,7 +40,15 @@ func (k Keeper) CalculateAndDistributeProtocolFees(
 		denomAmounts[coinTransfer.Denom] = denomAmounts[coinTransfer.Denom].Add(amount)
 	}
 
-	for denom, totalAmount := range denomAmounts {
+	// Sort map keys for deterministic iteration order
+	denoms := make([]string, 0, len(denomAmounts))
+	for denom := range denomAmounts {
+		denoms = append(denoms, denom)
+	}
+	sort.Strings(denoms)
+
+	for _, denom := range denoms {
+		totalAmount := denomAmounts[denom]
 		// 0.1% of the total amount for this denom
 		// Safety check to prevent division by zero
 		if ProtocolFeeDenominator == 0 {
@@ -49,7 +58,7 @@ func (k Keeper) CalculateAndDistributeProtocolFees(
 
 		// For other denoms, just use 0.1%
 		if !protocolFee.IsZero() {
-			protocolFees = protocolFees.Add(sdk.NewCoin(denom, sdkmath.NewIntFromUint64(protocolFee.Uint64())))
+			protocolFees = protocolFees.Add(sdk.NewCoin(denom, sdkmath.NewIntFromBigInt(protocolFee.BigInt())))
 		}
 	}
 


### PR DESCRIPTION
## Summary

Addresses 5 real findings from a systematic Cosmos SDK security audit of the chain:

- **Fix non-deterministic map iteration in voting challenge checker** (`voting_challenges.go`) — iterate over the original `Voters` slice instead of the `voterMap` to ensure deterministic ordering in consensus path
- **Fix non-deterministic map iteration + overflow panic in protocol fee calculation** (`transfer_utils.go`) — sort denom keys before iteration; replace `.Uint64()` with `NewIntFromBigInt()` to prevent panic on large values
- **Check error from `DeleteAllVotesForProposal`** (`approved_transfers.go`) — previously silently discarded with `_ =`, which could leave stale votes after `ResetAfterExecution`
- **Fix `OnChanOpenInit` returning wrong version** (`ibc_module.go`) — was returning the input `version` instead of the negotiated `finalVersion` from the underlying app
- **Fix `string(rune(len(...)))` in ICQ event** (`icq_queries.go`) — was emitting a Unicode character instead of the numeric count string

## Test plan

- [x] `go build ./...` passes
- [x] `go test -tags=test ./x/tokenization/...` — all pass
- [x] `go test -tags=test ./x/ibc-hooks/...` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)