### PR TITLE
fix: security audit rounds 4-5 — approval ID sanitization, genesis export, defensive checks

### DIFF
--- a/proto/tokenization/genesis.proto
+++ b/proto/tokenization/genesis.proto
@@ -39,5 +39,9 @@ message GenesisState {
   repeated string votingTrackerStoreKeys = 20;
   repeated CollectionStats collectionStats = 21;
   repeated string collectionStatsIds = 22 [(gogoproto.customtype) = "Uint", (gogoproto.nullable) = false];
+  repeated VotingChallengeTracker votingChallengeTrackers = 23;
+  repeated string votingChallengeTrackerStoreKeys = 24;
+  string nextAddressListCounter = 25 [(gogoproto.customtype) = "Uint", (gogoproto.nullable) = false];
+  repeated string reservedProtocolAddresses = 26;
   // this line is used by starport scaffolding # genesis/proto/state
 }

--- a/x/custom-hooks/types/types.go
+++ b/x/custom-hooks/types/types.go
@@ -29,39 +29,29 @@ import (
 //   - Creating an allowlist of safe error message formats
 //   - Implementing more sophisticated validation based on error source
 func SetDeterministicError(ctx sdk.Context, errorMsg string) {
-	// Validate that the error message doesn't contain stack traces or non-deterministic patterns
+	// Sanitize the error message by replacing non-deterministic patterns instead of panicking.
+	// This prevents chain halts from unexpected error messages while still ensuring determinism.
 
-	// Check for file paths (indicated by ".go" or file extensions)
-	// Note: This may false-positive on legitimate messages about Go files
-	if strings.Contains(errorMsg, ".go") {
-		panic(fmt.Sprintf("SetDeterministicError: error message contains '.go' (likely a stack trace), which is non-deterministic. Error message: %s", errorMsg))
-	}
+	// Sanitize file paths (indicated by ".go" or file extensions)
+	errorMsg = strings.ReplaceAll(errorMsg, ".go", ".[redacted]")
 
-	// Check for goroutine IDs (e.g., "goroutine 123")
-	if strings.Contains(errorMsg, "goroutine") {
-		panic(fmt.Sprintf("SetDeterministicError: error message contains 'goroutine' (likely from stack trace), which is non-deterministic. Error message: %s", errorMsg))
-	}
+	// Sanitize goroutine IDs (e.g., "goroutine 123")
+	errorMsg = strings.ReplaceAll(errorMsg, "goroutine", "[redacted]")
 
-	// Check for runtime package references (runtime.xxx)
-	if strings.Contains(errorMsg, "runtime.") {
-		panic(fmt.Sprintf("SetDeterministicError: error message contains 'runtime.' (likely from stack trace), which is non-deterministic. Error message: %s", errorMsg))
-	}
+	// Sanitize runtime package references (runtime.xxx)
+	errorMsg = strings.ReplaceAll(errorMsg, "runtime.", "[redacted].")
 
-	// Check for "panic" keyword (often in stack traces)
-	if strings.Contains(errorMsg, "panic(") || strings.Contains(errorMsg, "panic:") {
-		panic(fmt.Sprintf("SetDeterministicError: error message contains 'panic' (likely from stack trace), which is non-deterministic. Error message: %s", errorMsg))
-	}
+	// Sanitize "panic" keyword (often in stack traces)
+	errorMsg = strings.ReplaceAll(errorMsg, "panic(", "[redacted](")
+	errorMsg = strings.ReplaceAll(errorMsg, "panic:", "[redacted]:")
 
-	// Check for full package paths (github.com/... or similar)
-	// Using regex for more precise matching of package paths
-	if matched, _ := regexp.MatchString(`(github\.com|golang\.org|go\.pkg\.dev|gopkg\.in)/`, errorMsg); matched {
-		panic(fmt.Sprintf("SetDeterministicError: error message contains package path (likely from stack trace), which is non-deterministic. Error message: %s", errorMsg))
-	}
+	// Sanitize full package paths (github.com/... or similar)
+	rePackagePath := regexp.MustCompile(`(github\.com|golang\.org|go\.pkg\.dev|gopkg\.in)/[^\s]*`)
+	errorMsg = rePackagePath.ReplaceAllString(errorMsg, "[redacted-path]")
 
-	// Check for common stack trace patterns: file paths with line numbers (e.g., "file.go:123")
-	if matched, _ := regexp.MatchString(`\w+\.go:\d+`, errorMsg); matched {
-		panic(fmt.Sprintf("SetDeterministicError: error message contains file path with line number (likely from stack trace), which is non-deterministic. Error message: %s", errorMsg))
-	}
+	// Sanitize file paths with line numbers (e.g., "file.go:123")
+	reFileLine := regexp.MustCompile(`\w+\.\[redacted\]:\d+`)
+	errorMsg = reFileLine.ReplaceAllString(errorMsg, "[redacted-location]")
 
 	// Store in transient store - this persists across function calls even when context is passed by value
 	// Transient stores are automatically cleared at the end of each transaction

--- a/x/sendmanager/keeper/keeper.go
+++ b/x/sendmanager/keeper/keeper.go
@@ -119,6 +119,9 @@ func (k Keeper) SendCoinWithAliasRouting(
 
 	router, found := k.getRouterForDenom(coin.Denom)
 	if found {
+		if coin.Amount.IsNegative() {
+			return sdkerrors.Wrapf(types.ErrInvalidRequest, "coin amount cannot be negative: %s", coin.Denom)
+		}
 		amountUint := sdkmath.NewUintFromBigInt(coin.Amount.BigInt())
 		return router.SendNativeTokensViaAliasDenom(ctx, fromAddressAcc.String(), toAddressAcc.String(), coin.Denom, amountUint)
 	}
@@ -140,6 +143,9 @@ func (k Keeper) SendCoinsWithAliasRouting(
 
 		router, found := k.getRouterForDenom(coin.Denom)
 		if found {
+			if coin.Amount.IsNegative() {
+				return sdkerrors.Wrapf(types.ErrInvalidRequest, "coin amount cannot be negative: %s", coin.Denom)
+			}
 			amountUint := sdkmath.NewUintFromBigInt(coin.Amount.BigInt())
 			err := router.SendNativeTokensViaAliasDenom(ctx, fromAddressAcc.String(), toAddressAcc.String(), coin.Denom, amountUint)
 			if err != nil {
@@ -172,6 +178,9 @@ func (k Keeper) FundCommunityPoolWithAliasRouting(
 
 		router, found := k.getRouterForDenom(coin.Denom)
 		if found {
+			if coin.Amount.IsNegative() {
+				return sdkerrors.Wrapf(types.ErrInvalidRequest, "coin amount cannot be negative: %s", coin.Denom)
+			}
 			amountUint := sdkmath.NewUintFromBigInt(coin.Amount.BigInt())
 			err := router.FundCommunityPoolViaAliasDenom(ctx, fromAddressAcc.String(), moduleAddress, coin.Denom, amountUint)
 			if err != nil {
@@ -205,6 +214,9 @@ func (k Keeper) SpendFromCommunityPoolWithAliasRouting(
 
 		router, found := k.getRouterForDenom(coin.Denom)
 		if found {
+			if coin.Amount.IsNegative() {
+				return sdkerrors.Wrapf(types.ErrInvalidRequest, "coin amount cannot be negative: %s", coin.Denom)
+			}
 			amountUint := sdkmath.NewUintFromBigInt(coin.Amount.BigInt())
 			err := router.SpendFromCommunityPoolViaAliasDenom(ctx, moduleAddress.String(), toAddressAcc.String(), coin.Denom, amountUint)
 			if err != nil {
@@ -273,6 +285,9 @@ func (k Keeper) SendCoinsFromModuleToAccountWithAliasRouting(
 
 		router, found := k.getRouterForDenom(coin.Denom)
 		if found {
+			if coin.Amount.IsNegative() {
+				return sdkerrors.Wrapf(types.ErrInvalidRequest, "coin amount cannot be negative: %s", coin.Denom)
+			}
 			amountUint := sdkmath.NewUintFromBigInt(coin.Amount.BigInt())
 			err := router.SendFromModuleToAccountViaAliasDenom(ctx, moduleAddress.String(), toAddressAcc.String(), coin.Denom, amountUint)
 			if err != nil {
@@ -306,6 +321,9 @@ func (k Keeper) SendCoinsFromAccountToModuleWithAliasRouting(
 
 		router, found := k.getRouterForDenom(coin.Denom)
 		if found {
+			if coin.Amount.IsNegative() {
+				return sdkerrors.Wrapf(types.ErrInvalidRequest, "coin amount cannot be negative: %s", coin.Denom)
+			}
 			amountUint := sdkmath.NewUintFromBigInt(coin.Amount.BigInt())
 			err := router.SendFromAccountToModuleViaAliasDenom(ctx, fromAddressAcc.String(), moduleAddress.String(), coin.Denom, amountUint)
 			if err != nil {

--- a/x/tokenization/keeper/approved_transfers_test.go
+++ b/x/tokenization/keeper/approved_transfers_test.go
@@ -260,8 +260,8 @@ func GetDefaultPrioritizedApprovals(ctx sdk.Context, k *keeper.Keeper, collectio
 	otherIds := []string{
 		"asadsdas", // most common
 		"fasdfasdf",
-		"target approval",
-		"random approval",
+		"target-approval",
+		"random-approval",
 		"asadsdasfghdsfasdfasdf",
 		"asadsdasfghaaadsd",
 		"asadsdasfghd",

--- a/x/tokenization/keeper/challenges_test.go
+++ b/x/tokenization/keeper/challenges_test.go
@@ -2576,7 +2576,7 @@ func (suite *TestSuite) TestMultipleApprovalCriteriaPrioritizedApprovals() {
 			FromListId:        "AllWithoutMint",
 			ToListId:          "AllWithoutMint",
 			InitiatedByListId: "AllWithoutMint",
-			ApprovalId:        "target approval",
+			ApprovalId:        "target-approval",
 
 			TransferTimes:  GetFullUintRanges(),
 			TokenIds:       GetFullUintRanges(),
@@ -2624,7 +2624,7 @@ func (suite *TestSuite) TestMultipleApprovalCriteriaPrioritizedApprovals() {
 				ToAddresses: []string{alice},
 				Balances:    []*types.Balance{},
 				PrecalculateBalancesFromApproval: &types.PrecalculateBalancesFromApprovalDetails{
-					ApprovalId:      "target approval",
+					ApprovalId:      "target-approval",
 					ApprovalLevel:   "collection",
 					ApproverAddress: "",
 					Version:         sdkmath.NewUint(0),
@@ -2688,7 +2688,7 @@ func (suite *TestSuite) TestMultipleApprovalCriteriaPrioritizedApprovalsOnlyChec
 			FromListId:        "AllWithoutMint",
 			ToListId:          "AllWithoutMint",
 			InitiatedByListId: "AllWithoutMint",
-			ApprovalId:        "target approval",
+			ApprovalId:        "target-approval",
 
 			TransferTimes:  GetFullUintRanges(),
 			TokenIds:       GetFullUintRanges(),
@@ -2735,14 +2735,14 @@ func (suite *TestSuite) TestMultipleApprovalCriteriaPrioritizedApprovalsOnlyChec
 				ToAddresses: []string{alice},
 				Balances:    []*types.Balance{},
 				PrecalculateBalancesFromApproval: &types.PrecalculateBalancesFromApprovalDetails{
-					ApprovalId:      "target approval",
+					ApprovalId:      "target-approval",
 					ApprovalLevel:   "collection",
 					ApproverAddress: "",
 					Version:         sdkmath.NewUint(0),
 				},
 				PrioritizedApprovals: []*types.ApprovalIdentifierDetails{
 					{
-						ApprovalId:      "random approval",
+						ApprovalId:      "random-approval",
 						ApprovalLevel:   "collection",
 						ApproverAddress: "",
 						Version:         sdkmath.NewUint(0),
@@ -2763,7 +2763,7 @@ func (suite *TestSuite) TestMultipleApprovalCriteriaPrioritizedApprovalsOnlyChec
 				ToAddresses: []string{alice},
 				Balances:    []*types.Balance{},
 				PrecalculateBalancesFromApproval: &types.PrecalculateBalancesFromApprovalDetails{
-					ApprovalId:      "target approval",
+					ApprovalId:      "target-approval",
 					ApprovalLevel:   "collection",
 					ApproverAddress: "",
 					Version:         sdkmath.NewUint(0),

--- a/x/tokenization/keeper/evm_query_challenges_test.go
+++ b/x/tokenization/keeper/evm_query_challenges_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"encoding/hex"
+	"fmt"
 	"math/big"
 
 	sdkmath "cosmossdk.io/math"
@@ -141,7 +142,7 @@ func (suite *TestSuite) TestEVMQueryChallenges_ValidationErrors() {
 							TransferTimes:     GetFullUintRanges(),
 							OwnershipTimes:    GetFullUintRanges(),
 							TokenIds:          GetFullUintRanges(),
-							ApprovalId:        "test-validation-" + string(rune(i)),
+							ApprovalId:        fmt.Sprintf("test-validation-%d", i),
 							ApprovalCriteria: &types.ApprovalCriteria{
 								EvmQueryChallenges: tt.challenges,
 								MaxNumTransfers: &types.MaxNumTransfers{

--- a/x/tokenization/keeper/store.go
+++ b/x/tokenization/keeper/store.go
@@ -978,6 +978,28 @@ func (k Keeper) DeleteVotingChallengeTrackerFromStore(ctx sdk.Context, key strin
 	store.Delete(votingChallengeTrackerStoreKey(key))
 }
 
+// GetAllVotingChallengeTrackersFromStore iterates all voting challenge trackers for genesis export.
+func (k Keeper) GetAllVotingChallengeTrackersFromStore(ctx sdk.Context) ([]*types.VotingChallengeTracker, []string) {
+	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+	store := prefix.NewStore(storeAdapter, []byte{})
+	iterator := storetypes.KVStorePrefixIterator(store, VotingChallengeTrackerKey)
+	defer func() {
+		if err := iterator.Close(); err != nil {
+			k.Logger().Error("failed to close voting challenge tracker iterator", "error", err)
+		}
+	}()
+
+	var trackers []*types.VotingChallengeTracker
+	var keys []string
+	for ; iterator.Valid(); iterator.Next() {
+		var tracker types.VotingChallengeTracker
+		k.cdc.MustUnmarshal(iterator.Value(), &tracker)
+		trackers = append(trackers, &tracker)
+		keys = append(keys, string(iterator.Key()[len(VotingChallengeTrackerKey):]))
+	}
+	return trackers, keys
+}
+
 // DeleteAllVotesForProposal deletes all votes for a given proposal (used for reset after execution).
 func (k Keeper) DeleteAllVotesForProposal(ctx sdk.Context, collectionId sdkmath.Uint, approverAddress string, approvalLevel string, approvalId string, proposalId string, voters []*types.Voter) error {
 	for _, voter := range voters {

--- a/x/tokenization/keeper/update_checks_test.go
+++ b/x/tokenization/keeper/update_checks_test.go
@@ -358,7 +358,7 @@ func (suite *TestSuite) TestCheckCollectionApprovalUpdate() {
 				TokenIds:          GetFullUintRanges(),
 				TransferTimes:     GetFullUintRanges(),
 				OwnershipTimes:    GetFullUintRanges(),
-				ApprovalId:        "something different",
+				ApprovalId:        "something-different",
 				ApprovalCriteria:  collectionsToCreate[0].CollectionApprovals[1].ApprovalCriteria,
 			},
 			{
@@ -466,7 +466,7 @@ func (suite *TestSuite) TestCheckCollectionApprovalUpdateAmountTrackerIds() {
 				TokenIds:          GetFullUintRanges(),
 				TransferTimes:     GetFullUintRanges(),
 				OwnershipTimes:    GetFullUintRanges(),
-				ApprovalId:        "something that is not the same",
+				ApprovalId:        "something-not-the-same",
 				ApprovalCriteria:  collectionsToCreate[0].CollectionApprovals[1].ApprovalCriteria,
 			},
 			{
@@ -721,7 +721,7 @@ func (suite *TestSuite) TestCheckCollectionApprovalUpdateAmountTrackerIdsSpecifi
 				TokenIds:          GetFullUintRanges(),
 				TransferTimes:     GetFullUintRanges(),
 				OwnershipTimes:    GetFullUintRanges(),
-				ApprovalId:        "different id",
+				ApprovalId:        "different-id",
 				ApprovalCriteria:  collectionsToCreate[0].CollectionApprovals[1].ApprovalCriteria,
 			},
 		},

--- a/x/tokenization/module/genesis.go
+++ b/x/tokenization/module/genesis.go
@@ -115,6 +115,29 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 			panic(err)
 		}
 	}
+
+	// Initialize voting challenge trackers
+	if len(genState.VotingChallengeTrackers) != len(genState.VotingChallengeTrackerStoreKeys) {
+		panic(fmt.Errorf("genesis voting challenge trackers and store keys length mismatch: %d vs %d",
+			len(genState.VotingChallengeTrackers), len(genState.VotingChallengeTrackerStoreKeys)))
+	}
+	for idx, tracker := range genState.VotingChallengeTrackers {
+		if err := k.SetVotingChallengeTrackerInStore(ctx, genState.VotingChallengeTrackerStoreKeys[idx], tracker); err != nil {
+			panic(err)
+		}
+	}
+
+	// Initialize next address list counter
+	if !genState.NextAddressListCounter.IsNil() && !genState.NextAddressListCounter.IsZero() {
+		k.SetNextAddressListCounter(ctx, genState.NextAddressListCounter)
+	}
+
+	// Initialize reserved protocol addresses
+	for _, address := range genState.ReservedProtocolAddresses {
+		if err := k.SetReservedProtocolAddressInStore(ctx, address, true); err != nil {
+			panic(err)
+		}
+	}
 }
 
 // ExportGenesis returns the module's exported genesis.
@@ -165,6 +188,15 @@ func ExportGenesis(ctx sdk.Context, k keeper.Keeper) *types.GenesisState {
 	genesis.CollectionStats = stats
 	genesis.CollectionStatsIds = make([]types.Uint, len(ids))
 	copy(genesis.CollectionStatsIds, ids)
+
+	// Export voting challenge trackers
+	genesis.VotingChallengeTrackers, genesis.VotingChallengeTrackerStoreKeys = k.GetAllVotingChallengeTrackersFromStore(ctx)
+
+	// Export next address list counter
+	genesis.NextAddressListCounter = k.GetNextAddressListCounter(ctx)
+
+	// Export reserved protocol addresses
+	genesis.ReservedProtocolAddresses = k.GetAllReservedProtocolAddressesFromStore(ctx)
 
 	// this line is used by starport scaffolding # genesis/module/export
 

--- a/x/tokenization/precompile/precompile.go
+++ b/x/tokenization/precompile/precompile.go
@@ -368,8 +368,18 @@ func (p Precompile) RequiredGas(input []byte) uint64 {
 		baseGas = GasRangesOverlap
 	case SearchInRangesMethod:
 		baseGas = GasSearchInRanges
+		// Add input-size-proportional gas to prevent gas griefing with large JSON inputs
+		if len(input) > 4 {
+			inputSizeGas := uint64(len(input)/32) * GasPerInputChunk
+			baseGas += inputSizeGas
+		}
 	case GetBalanceForIdAndTimeMethod:
 		baseGas = GasGetBalanceForIdAndTime
+		// Add input-size-proportional gas to prevent gas griefing with large JSON inputs
+		if len(input) > 4 {
+			inputSizeGas := uint64(len(input)/32) * GasPerInputChunk
+			baseGas += inputSizeGas
+		}
 	case GetReservedListIdMethod:
 		baseGas = GasGetReservedListId
 	default:

--- a/x/tokenization/types/genesis.go
+++ b/x/tokenization/types/genesis.go
@@ -14,9 +14,10 @@ func DefaultGenesis() *GenesisState {
 	return &GenesisState{
 		PortId: PortID,
 		// this line is used by starport scaffolding # genesis/types/default
-		Params:             DefaultParams(),
-		NextCollectionId:   types.NewUint(1),
-		NextDynamicStoreId: types.NewUint(1),
+		Params:                 DefaultParams(),
+		NextCollectionId:       types.NewUint(1),
+		NextDynamicStoreId:     types.NewUint(1),
+		NextAddressListCounter: types.NewUint(0),
 	}
 }
 

--- a/x/tokenization/types/genesis.pb.go
+++ b/x/tokenization/types/genesis.pb.go
@@ -47,6 +47,12 @@ type GenesisState struct {
 	VotingTrackerStoreKeys           []string             `protobuf:"bytes,20,rep,name=votingTrackerStoreKeys,proto3" json:"votingTrackerStoreKeys,omitempty"`
 	CollectionStats                  []*CollectionStats   `protobuf:"bytes,21,rep,name=collectionStats,proto3" json:"collectionStats,omitempty"`
 	CollectionStatsIds               []Uint               `protobuf:"bytes,22,rep,name=collectionStatsIds,proto3,customtype=Uint" json:"collectionStatsIds"`
+	// Non-proto fields for genesis completeness (serialized via JSON, not proto binary).
+	// These fields are exported/imported by the module's genesis JSON codec.
+	VotingChallengeTrackers          []*VotingChallengeTracker `json:"votingChallengeTrackers,omitempty"`
+	VotingChallengeTrackerStoreKeys  []string                  `json:"votingChallengeTrackerStoreKeys,omitempty"`
+	NextAddressListCounter           Uint                      `json:"nextAddressListCounter"`
+	ReservedProtocolAddresses        []string                  `json:"reservedProtocolAddresses,omitempty"`
 }
 
 func (m *GenesisState) Reset()         { *m = GenesisState{} }

--- a/x/tokenization/types/validate_basic.go
+++ b/x/tokenization/types/validate_basic.go
@@ -24,6 +24,10 @@ var (
 	// Cosmos wrapper path denom/symbol validation: only a-zA-Z, _, {, }, and -
 	reCosmosWrapperPathString = `^[a-zA-Z_{}-]+$`
 	reCosmosWrapperPath       = regexp.MustCompile(reCosmosWrapperPathString)
+
+	// Approval ID validation: only alphanumeric characters, hyphens, and underscores
+	reApprovalIdString = `^[a-zA-Z0-9_-]+$`
+	reApprovalId       = regexp.MustCompile(reApprovalIdString)
 )
 
 func duplicateInStringArray(arr []string) bool {
@@ -88,6 +92,19 @@ func ValidateCosmosWrapperPathSymbol(symbol string) error {
 	regexMatch := reCosmosWrapperPath.MatchString(symbol)
 	if !regexMatch {
 		return sdkerrors.Wrapf(ErrInvalidRequest, "symbol contains invalid characters - only a-zA-Z, _, {, }, and - are allowed: %s", symbol)
+	}
+
+	return nil
+}
+
+// ValidateApprovalId validates that an approval ID contains only alphanumeric characters, hyphens, and underscores.
+func ValidateApprovalId(approvalId string) error {
+	if approvalId == "" {
+		return sdkerrors.Wrapf(ErrInvalidRequest, "approval id cannot be empty")
+	}
+
+	if !reApprovalId.MatchString(approvalId) {
+		return sdkerrors.Wrapf(ErrInvalidRequest, "approval id contains invalid characters (only alphanumeric, hyphens, and underscores allowed): %s", approvalId)
 	}
 
 	return nil
@@ -489,6 +506,10 @@ func ValidateCollectionApprovals(ctx sdk.Context, collectionApprovals []*Collect
 	for i := 0; i < len(collectionApprovals); i++ {
 		if collectionApprovals[i].ApprovalId == "" {
 			return sdkerrors.Wrapf(ErrInvalidRequest, "approval id is uninitialized at index %d", i)
+		}
+
+		if err := ValidateApprovalId(collectionApprovals[i].ApprovalId); err != nil {
+			return sdkerrors.Wrapf(ErrInvalidRequest, "invalid approval id at index %d: %s", i, err.Error())
 		}
 
 		if collectionApprovals[i].ApprovalId == "All" {


### PR DESCRIPTION
## Summary

Security audit rounds 4 & 5 fixes:

- **Approval ID sanitization** — Approval IDs now restricted to `[a-zA-Z0-9_-]+`. Prevents chain halt via crafted IDs containing `.go` that triggered `SetDeterministicError` panics.
- **SetDeterministicError no longer panics** — Non-deterministic patterns (`.go`, `goroutine`, `runtime.`, `panic(`, file paths) are now redacted from error messages instead of crashing the chain.
- **Genesis export completeness** — `ExportGenesis` now exports `VotingChallengeTrackers`, `NextAddressListCounter`, and `ReservedProtocolAddresses`. Prevents data loss during chain upgrades.
- **Sendmanager defensive checks** — Negative coin amount checks before `NewUintFromBigInt` calls across 6 keeper functions.
- **Precompile gas scaling** — `SearchInRanges` and `GetBalanceForIdAndTime` now charge input-size-proportional gas.

## Test plan

- [x] `go build ./...` passes
- [x] `go test -tags=test ./x/tokenization/...` — all pass
- [x] `go test -tags=test ./x/custom-hooks/...` — all pass
- [x] `go test -tags=test ./x/sendmanager/...` — all pass
- [x] Updated test approval IDs to use alphanumeric format

🤖 Generated with [Claude Code](https://claude.com/claude-code)