### PR TITLE
feat: migrate CLI delegation + install instructions to 'bitbadges' package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,7 +181,7 @@ jobs:
 
             **SDK CLI:**
             ```bash
-            npm install -g bitbadgesjs-sdk
+            npm install -g bitbadges
             ```
 
             ## Binaries

--- a/cmd/bitbadgeschaind/cmd/api_cmd.go
+++ b/cmd/bitbadgeschaind/cmd/api_cmd.go
@@ -20,7 +20,7 @@ func ApiCmd() *cobra.Command {
 Queries the BitBadges indexer (not the on-chain node). Includes: collections,
 balances, claims, plugins, DEX pools, asset pairs, dynamic stores, and 100+ routes.
 
-Requires: Node.js + bitbadges-cli (npm install -g bitbadgesjs-sdk)
+Requires: Node.js + bitbadges-cli (npm install -g bitbadges)
 Configure: BITBADGES_API_KEY env var or bitbadges-cli config set apiKey <key>`,
 		DisableFlagParsing: true, // Pass all flags through to Node.js CLI
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/bitbadgeschaind/cmd/builder_cmd.go
+++ b/cmd/bitbadgeschaind/cmd/builder_cmd.go
@@ -30,7 +30,7 @@ reviews (review_collection), and utilities
 Session state persists per-id under ~/.bitbadges/sessions/<id>.json so you can
 compose a collection across multiple invocations.
 
-Requires: Node.js + bitbadges-cli (npm install -g bitbadgesjs-sdk)`,
+Requires: Node.js + bitbadges-cli (npm install -g bitbadges)`,
 		DisableFlagParsing: true, // Pass all flags through to Node.js CLI
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return execNodeCLI("builder", args)

--- a/cmd/bitbadgeschaind/cmd/node_cli.go
+++ b/cmd/bitbadgeschaind/cmd/node_cli.go
@@ -13,15 +13,15 @@ import (
 func execNodeCLI(subcommand string, args []string) error {
 	cliPath, useNpx := findNodeCLI()
 	if cliPath == "" {
-		fmt.Fprintln(os.Stderr, "SDK CLI not available. Install with: npm install -g bitbadgesjs-sdk (provides bitbadges-cli command)")
+		fmt.Fprintln(os.Stderr, "SDK CLI not available. Install with: npm install -g bitbadges (provides bitbadges-cli command)")
 		fmt.Fprintln(os.Stderr, "Or set BITBADGES_SDK_CLI_PATH environment variable.")
 		return nil // Don't error - chain operations should still work
 	}
 
 	var fullArgs []string
 	if useNpx {
-		// npx -p bitbadgesjs-sdk bitbadges-cli <subcommand> <args...>
-		fullArgs = append([]string{"-p", "bitbadgesjs-sdk", "bitbadges-cli", subcommand}, args...)
+		// npx -p bitbadges bitbadges-cli <subcommand> <args...>
+		fullArgs = append([]string{"-p", "bitbadges", "bitbadges-cli", subcommand}, args...)
 	} else {
 		// <binary> <subcommand> <args...>
 		fullArgs = append([]string{subcommand}, args...)

--- a/cmd/bitbadgeschaind/cmd/sdk_cmd.go
+++ b/cmd/bitbadgeschaind/cmd/sdk_cmd.go
@@ -20,7 +20,7 @@ func SdkCmd() *cobra.Command {
 Includes: collection/transaction review, interpret, address conversion,
 alias generation, token lookup, builder skill docs, and more.
 
-Requires: Node.js + bitbadges-cli (npm install -g bitbadgesjs-sdk)`,
+Requires: Node.js + bitbadges-cli (npm install -g bitbadges)`,
 		DisableFlagParsing: true, // Pass all flags through to Node.js CLI
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return execNodeCLI("sdk", args)

--- a/install.sh
+++ b/install.sh
@@ -202,13 +202,13 @@ main() {
   echo ""
   if command -v bun >/dev/null 2>&1; then
     echo "Installing BitBadges SDK CLI (bitbadges-cli) via bun..."
-    bun install -g bitbadgesjs-sdk 2>&1 | tail -1
+    bun install -g bitbadges 2>&1 | tail -1
   elif command -v npm >/dev/null 2>&1; then
     echo "Installing BitBadges SDK CLI (bitbadges-cli) via npm..."
-    npm install -g bitbadgesjs-sdk 2>&1 | tail -1
+    npm install -g bitbadges 2>&1 | tail -1
   else
     echo "npm/bun not found — skipping SDK CLI install. To install later:"
-    echo "  npm install -g bitbadgesjs-sdk"
+    echo "  npm install -g bitbadges"
   fi
 
   if command -v bitbadges-cli >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

The BitBadges SDK has been renamed on npm: \`bitbadgesjs-sdk\` → \`bitbadges\`. The chain binary delegates \`sdk\` / \`api\` / \`builder\` subcommands to the Node \`bitbadges-cli\` via \`npx\`; this updates the subprocess args and all user-facing install instructions.

- **\`cmd/bitbadgeschaind/cmd/node_cli.go\`**: \`npx\` subprocess args \`-p bitbadgesjs-sdk bitbadges-cli\` → \`-p bitbadges bitbadges-cli\`; install hint in "SDK CLI not available" error
- **\`cmd/bitbadgeschaind/cmd/{sdk,api,builder}_cmd.go\`**: command help text install instructions
- **\`install.sh\`**: 3 install commands (bun + npm) + help text
- **\`.github/workflows/release.yml\`**: CI install command

Filesystem path references in \`_docs/\` left unchanged — the package directory remains \`packages/bitbadgesjs-sdk/\` in the bitbadgesjs monorepo, only the npm package name changed.

## Base branch

Targeting \`feat/v30\` per discussion.

## Test plan

- [x] \`go build ./cmd/bitbadgeschaind/\` — clean
- [ ] Functional test of \`bitbadgeschaind sdk/api/builder\` commands with fresh \`npm install -g bitbadges\` — recommended before merge

## Related

- SDK rename PR: https://github.com/BitBadges/bitbadgesjs/pull/149
- Frontend migration: https://github.com/BitBadges/bitbadges-frontend/pull/130
- Indexer migration: https://github.com/BitBadges/bitbadges-indexer/pull/95
- \`bitbadges@0.34.1\` on npm: https://www.npmjs.com/package/bitbadges

🤖 Generated with [Claude Code](https://claude.com/claude-code)