### PR TITLE
fix(tokenization): bound AltTimeChecks v29 fields in ValidateBasic

### DIFF
--- a/x/tokenization/approval_criteria/alt_time_checks.go
+++ b/x/tokenization/approval_criteria/alt_time_checks.go
@@ -38,7 +38,20 @@ func (c *AltTimeChecksChecker) Check(ctx sdk.Context, approval *types.Collection
 	blockTime := ctx.BlockTime()
 	localTime := blockTime.UTC()
 	if c.altTimeChecks.TimezoneOffsetMinutes.GT(sdkmath.NewUint(0)) {
-		offsetDuration := time.Duration(c.altTimeChecks.TimezoneOffsetMinutes.Uint64()) * time.Minute
+		// Defense-in-depth: ValidateAltTimeChecks bounds this to ≤ 14*60
+		// minutes, but if a checker is ever constructed outside that path
+		// (e.g. corrupt migrated state), reject rather than panic or wrap.
+		// Values that don't fit in uint64 would panic in .Uint64(); values
+		// in [2^63, 2^64-1] would silently wrap through int64 overflow
+		// when multiplied by time.Minute.
+		if !c.altTimeChecks.TimezoneOffsetMinutes.BigInt().IsUint64() {
+			return "", sdkerrors.Wrapf(types.ErrInvalidRequest, "timezoneOffsetMinutes exceeds uint64 range")
+		}
+		offsetMinutes := c.altTimeChecks.TimezoneOffsetMinutes.Uint64()
+		if offsetMinutes > types.MaxTimezoneOffsetMinutes {
+			return "", sdkerrors.Wrapf(types.ErrInvalidRequest, "timezoneOffsetMinutes %d exceeds maximum real-world offset of %d minutes", offsetMinutes, types.MaxTimezoneOffsetMinutes)
+		}
+		offsetDuration := time.Duration(offsetMinutes) * time.Minute
 		if c.altTimeChecks.TimezoneOffsetNegative {
 			localTime = localTime.Add(-offsetDuration)
 		} else {

--- a/x/tokenization/types/validate_basic.go
+++ b/x/tokenization/types/validate_basic.go
@@ -230,7 +230,22 @@ func ValidateNoStringElementIsX(addresses []string, x string) error {
 	return nil
 }
 
-// ValidateAltTimeChecks validates alt time checks for offline hours and days
+// MaxTimezoneOffsetMinutes is the widest real-world UTC offset in minutes
+// (UTC+14:00 is observed in Kiribati; UTC-12:00 is the westernmost common
+// offset). We bound |offset| ≤ 14 * 60 = 840 regardless of sign. Anything
+// larger is either a malformed client or a griefing attempt.
+const MaxTimezoneOffsetMinutes = uint64(14 * 60)
+
+// ValidateAltTimeChecks validates alt time checks for offline hours, days,
+// months, days-of-month, weeks-of-year, and the timezone offset magnitude.
+//
+// All fields originate from attacker-controlled messages (e.g.
+// MsgSetIncomingApproval). Without these bounds, a caller can set
+// TimezoneOffsetMinutes to an arbitrary sdkmath.Uint, which would later
+// panic during transfer evaluation when the consumer calls .Uint64() on an
+// out-of-uint64-range value, or silently wrap through int64 overflow for
+// values in [2^63, 2^64-1]. We reject at validate-basic time so the producer
+// fails fast rather than the consumer band-aiding.
 func ValidateAltTimeChecks(altTimeChecks *AltTimeChecks) error {
 	if altTimeChecks == nil {
 		return nil
@@ -241,9 +256,40 @@ func ValidateAltTimeChecks(altTimeChecks *AltTimeChecks) error {
 		return err
 	}
 
-	// Validate offline days (0-6)
+	// Validate offline days of week (0-6, Sunday..Saturday)
 	if err := validateTimeRanges(altTimeChecks.OfflineDays, 0, 6, "offline days"); err != nil {
 		return err
+	}
+
+	// Validate offline months (1-12, January..December)
+	if err := validateTimeRanges(altTimeChecks.OfflineMonths, 1, 12, "offline months"); err != nil {
+		return err
+	}
+
+	// Validate offline days of month (1-31)
+	if err := validateTimeRanges(altTimeChecks.OfflineDaysOfMonth, 1, 31, "offline days of month"); err != nil {
+		return err
+	}
+
+	// Validate offline weeks of year (1-53, ISO 8601 week numbering).
+	// ISO weeks can be 53 in long years (e.g. 2020, 2026), so upper bound is 53.
+	if err := validateTimeRanges(altTimeChecks.OfflineWeeksOfYear, 1, 53, "offline weeks of year"); err != nil {
+		return err
+	}
+
+	// Validate timezone offset magnitude. The proto field is an sdkmath.Uint
+	// (arbitrary 256-bit), so we must defend against values that would panic
+	// or silently wrap when converted to a time.Duration later in
+	// x/tokenization/approval_criteria/alt_time_checks.go.
+	if !altTimeChecks.TimezoneOffsetMinutes.IsNil() {
+		// Reject anything that doesn't fit in uint64 (would panic in .Uint64()).
+		if !altTimeChecks.TimezoneOffsetMinutes.BigInt().IsUint64() {
+			return sdkerrors.Wrapf(ErrInvalidRequest, "timezoneOffsetMinutes exceeds uint64 range (max real-world offset is %d minutes)", MaxTimezoneOffsetMinutes)
+		}
+		offsetMinutes := altTimeChecks.TimezoneOffsetMinutes.Uint64()
+		if offsetMinutes > MaxTimezoneOffsetMinutes {
+			return sdkerrors.Wrapf(ErrInvalidRequest, "timezoneOffsetMinutes %d exceeds maximum real-world offset of %d minutes (±14 hours from UTC)", offsetMinutes, MaxTimezoneOffsetMinutes)
+		}
 	}
 
 	return nil
@@ -271,10 +317,29 @@ func validateTimeRanges(ranges []*UintRange, min, max uint64, fieldName string) 
 			return sdkerrors.Wrapf(ErrUintUnititialized, "%s range at index %d has nil start or end", fieldName, i)
 		}
 
+		// Reject values that do not fit in uint64 before calling .Uint64(),
+		// which would panic on overflow. The subsequent `start > max` /
+		// `end > max` checks will then reject values that fit in uint64 but
+		// exceed the field's logical max.
+		if !r.Start.BigInt().IsUint64() {
+			return sdkerrors.Wrapf(ErrInvalidRequest, "%s range at index %d has start value that exceeds uint64 range (maximum is %d)", fieldName, i, max)
+		}
+		if !r.End.BigInt().IsUint64() {
+			return sdkerrors.Wrapf(ErrInvalidRequest, "%s range at index %d has end value that exceeds uint64 range (maximum is %d)", fieldName, i, max)
+		}
+
 		start := r.Start.Uint64()
 		end := r.End.Uint64()
 
-		// Check that start and end are within valid range (0 to max, inclusive)
+		// Check that start and end are within valid range [min, max] inclusive.
+		if start < min {
+			return sdkerrors.Wrapf(ErrInvalidRequest, "%s range at index %d has start value %d which is below minimum %d", fieldName, i, start, min)
+		}
+
+		if end < min {
+			return sdkerrors.Wrapf(ErrInvalidRequest, "%s range at index %d has end value %d which is below minimum %d", fieldName, i, end, min)
+		}
+
 		if start > max {
 			return sdkerrors.Wrapf(ErrInvalidRequest, "%s range at index %d has start value %d which exceeds maximum %d", fieldName, i, start, max)
 		}

--- a/x/tokenization/types/validate_basic_test.go
+++ b/x/tokenization/types/validate_basic_test.go
@@ -362,16 +362,166 @@ func TestValidateAltTimeChecks(t *testing.T) {
 			},
 			expectError: false,
 		},
+		// --- v29 field coverage: OfflineMonths (1-12) ---
+		{
+			name: "valid offline months boundary - should pass",
+			altTimeChecks: &AltTimeChecks{
+				OfflineMonths: []*UintRange{
+					{Start: sdkmath.NewUint(1), End: sdkmath.NewUint(12)},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "offline months start below minimum (0) - should fail",
+			altTimeChecks: &AltTimeChecks{
+				OfflineMonths: []*UintRange{
+					{Start: sdkmath.NewUint(0), End: sdkmath.NewUint(5)},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "offline months end exceeds 12 - should fail",
+			altTimeChecks: &AltTimeChecks{
+				OfflineMonths: []*UintRange{
+					{Start: sdkmath.NewUint(1), End: sdkmath.NewUint(13)},
+				},
+			},
+			expectError: true,
+		},
+		// --- v29 field coverage: OfflineDaysOfMonth (1-31) ---
+		{
+			name: "valid offline days of month boundary - should pass",
+			altTimeChecks: &AltTimeChecks{
+				OfflineDaysOfMonth: []*UintRange{
+					{Start: sdkmath.NewUint(1), End: sdkmath.NewUint(31)},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "offline days of month start 0 - should fail",
+			altTimeChecks: &AltTimeChecks{
+				OfflineDaysOfMonth: []*UintRange{
+					{Start: sdkmath.NewUint(0), End: sdkmath.NewUint(15)},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "offline days of month end 32 - should fail",
+			altTimeChecks: &AltTimeChecks{
+				OfflineDaysOfMonth: []*UintRange{
+					{Start: sdkmath.NewUint(1), End: sdkmath.NewUint(32)},
+				},
+			},
+			expectError: true,
+		},
+		// --- v29 field coverage: OfflineWeeksOfYear (1-53, ISO-week upper bound) ---
+		{
+			name: "valid offline weeks of year boundary 53 - should pass",
+			altTimeChecks: &AltTimeChecks{
+				OfflineWeeksOfYear: []*UintRange{
+					{Start: sdkmath.NewUint(1), End: sdkmath.NewUint(53)},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "offline weeks of year start 0 - should fail",
+			altTimeChecks: &AltTimeChecks{
+				OfflineWeeksOfYear: []*UintRange{
+					{Start: sdkmath.NewUint(0), End: sdkmath.NewUint(10)},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "offline weeks of year end 54 - should fail",
+			altTimeChecks: &AltTimeChecks{
+				OfflineWeeksOfYear: []*UintRange{
+					{Start: sdkmath.NewUint(1), End: sdkmath.NewUint(54)},
+				},
+			},
+			expectError: true,
+		},
+		// --- v29 field coverage: TimezoneOffsetMinutes (0..840) ---
+		{
+			name: "timezone offset zero (UTC) - should pass",
+			altTimeChecks: &AltTimeChecks{
+				TimezoneOffsetMinutes: sdkmath.NewUint(0),
+			},
+			expectError: false,
+		},
+		{
+			name: "timezone offset 300 (EST) - should pass",
+			altTimeChecks: &AltTimeChecks{
+				TimezoneOffsetMinutes: sdkmath.NewUint(300),
+			},
+			expectError: false,
+		},
+		{
+			name: "timezone offset 840 (UTC+14:00 Kiribati - max real-world) - should pass",
+			altTimeChecks: &AltTimeChecks{
+				TimezoneOffsetMinutes: sdkmath.NewUint(840),
+			},
+			expectError: false,
+		},
+		{
+			name: "timezone offset 841 (just over max real-world) - should fail",
+			altTimeChecks: &AltTimeChecks{
+				TimezoneOffsetMinutes: sdkmath.NewUint(841),
+			},
+			expectError: true,
+		},
+		{
+			name: "timezone offset in silent-wrap range [2^63+1] - should fail",
+			altTimeChecks: &AltTimeChecks{
+				// 2^63 + 1 — fits in uint64 but time.Duration(u64) * time.Minute
+				// silently wraps through int64 overflow at the consumer.
+				TimezoneOffsetMinutes: sdkmath.NewUintFromString("9223372036854775809"),
+			},
+			expectError: true,
+		},
+		{
+			name: "timezone offset at uint64 max - should fail",
+			altTimeChecks: &AltTimeChecks{
+				TimezoneOffsetMinutes: sdkmath.NewUintFromString("18446744073709551615"),
+			},
+			expectError: true,
+		},
+		{
+			name: "timezone offset exceeds uint64 (2^64) - should fail without panic",
+			altTimeChecks: &AltTimeChecks{
+				// 2^64 — would panic in .Uint64() at the consumer. Must be
+				// caught by ValidateBasic with a regular error, not a panic.
+				TimezoneOffsetMinutes: sdkmath.NewUintFromString("18446744073709551616"),
+			},
+			expectError: true,
+		},
+		{
+			name: "timezone offset 200-bit value - should fail without panic",
+			altTimeChecks: &AltTimeChecks{
+				// Larger than 2^64 and well into sdkmath.Uint territory.
+				TimezoneOffsetMinutes: sdkmath.NewUintFromString("1606938044258990275541962092341162602522202993782792835301376"),
+			},
+			expectError: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateAltTimeChecks(tt.altTimeChecks)
-			if tt.expectError {
-				require.Error(t, err, "expected error but got none")
-			} else {
-				require.NoError(t, err, "expected no error but got: %v", err)
-			}
+			// The fix must never panic — attacker-controlled values going
+			// into validate_basic should yield errors, not crashes.
+			require.NotPanics(t, func() {
+				err := ValidateAltTimeChecks(tt.altTimeChecks)
+				if tt.expectError {
+					require.Error(t, err, "expected error but got none")
+				} else {
+					require.NoError(t, err, "expected no error but got: %v", err)
+				}
+			})
 		})
 	}
 }


### PR DESCRIPTION
## Summary

`ValidateAltTimeChecks` previously only bounded `OfflineHours` and `OfflineDays`. The v29-added fields — `OfflineMonths`, `OfflineDaysOfMonth`, `OfflineWeeksOfYear`, and `TimezoneOffsetMinutes` — had no bounds. Since `TimezoneOffsetMinutes` is an `sdkmath.Uint` any user can set via `MsgSetIncomingApproval`, this was a transfer-level griefing DoS: a malicious counterparty could populate their approval with an out-of-range offset, causing every transfer routed through that approval to fail at the checker stage.

Scope: **transfer-level griefing only.** No chain-halt risk (the failure mode is a deterministic tx-level panic / silent wrap, same on every node), and no direct fund loss. The blast radius is limited to transfers matched against the attacker's own approval.

Implements backlog #0255.

## Bounds chosen

| Field | Bound | Rationale |
|-------|-------|-----------|
| `OfflineMonths` | [1, 12] | Calendar months. |
| `OfflineDaysOfMonth` | [1, 31] | Max days in a month. |
| `OfflineWeeksOfYear` | [1, 53] | ISO 8601 weeks can reach 53 in long years (e.g. 2020, 2026). |
| `TimezoneOffsetMinutes` | [0, 840] | 840 = 14·60. UTC+14:00 (Kiribati) is the widest real-world UTC offset; UTC-12:00 is the westernmost common offset. Magnitude-only — sign comes from the separate `TimezoneOffsetNegative` bool. |

## Changes

- `x/tokenization/types/validate_basic.go` — `ValidateAltTimeChecks` now bounds all five v29 fields. A new `MaxTimezoneOffsetMinutes` constant (840) is exposed for the consumer's defense-in-depth check. `validateTimeRanges` also rejects values that don't fit in `uint64` before calling `.Uint64()` (which would panic), and enforces the `min` bound it was already accepting as a parameter but silently ignoring.
- `x/tokenization/approval_criteria/alt_time_checks.go` — defense-in-depth: reject out-of-range `TimezoneOffsetMinutes` with an error instead of panicking / wrapping, in case a checker is ever constructed outside the validate-basic path (corrupt migrated state, custom caller, etc.). Follows the throw-not-bandaid principle.
- `x/tokenization/types/validate_basic_test.go` — 17 new subtests covering:
  - Valid boundary values for each new field.
  - Below-minimum rejection (OfflineMonths=0, OfflineDaysOfMonth=0, OfflineWeeksOfYear=0).
  - Above-maximum rejection (OfflineMonths=13, OfflineDaysOfMonth=32, OfflineWeeksOfYear=54).
  - TimezoneOffsetMinutes: 0, 300 (EST), 840 (Kiribati) accepted; 841 rejected.
  - TimezoneOffsetMinutes overflow cases: `2^63+1` (silent-wrap range), `2^64-1` (uint64 max), `2^64` (would panic at consumer), a 200-bit value — all rejected with error, never panic. Wrapped in `require.NotPanics` to prove the fix is complete.

## Test plan

- [x] `go test -tags=test ./x/tokenization/...` — all packages pass (see output below).
- [x] `go test -tags=test -run TestValidateAltTimeChecks -v ./x/tokenization/types/` — all 33 subtests PASS.
- [ ] Reviewer: confirm bound values are acceptable for the product's compliance-gating use cases (business-hours trading, sanctions day lockouts).

### Test output

```
ok  	github.com/bitbadges/bitbadgeschain/x/tokenization/ai_test/fuzz/messages	0.084s
ok  	github.com/bitbadges/bitbadgeschain/x/tokenization/ai_test/fuzz/transfers	0.083s
ok  	github.com/bitbadges/bitbadgeschain/x/tokenization/ai_test/integration/approval_criteria	0.184s
ok  	github.com/bitbadges/bitbadgeschain/x/tokenization/ai_test/integration/approvals	0.088s
ok  	github.com/bitbadges/bitbadgeschain/x/tokenization/ai_test/integration/challenges	0.136s
ok  	github.com/bitbadges/bitbadgeschain/x/tokenization/ai_test/integration/collections	0.111s
ok  	github.com/bitbadges/bitbadgeschain/x/tokenization/ai_test/integration/permissions	0.088s
ok  	github.com/bitbadges/bitbadgeschain/x/tokenization/ai_test/integration/transfers	0.090s
ok  	github.com/bitbadges/bitbadgeschain/x/tokenization/ai_test/security/attack_scenarios	0.079s
ok  	github.com/bitbadges/bitbadgeschain/x/tokenization/ai_test/security/edge_cases	0.139s
ok  	github.com/bitbadges/bitbadgeschain/x/tokenization/ai_test/security/invariants	0.101s
ok  	github.com/bitbadges/bitbadgeschain/x/tokenization/ai_test/unit/genesis	0.089s
ok  	github.com/bitbadges/bitbadgeschain/x/tokenization/ai_test/unit/keeper	0.068s
ok  	github.com/bitbadges/bitbadgeschain/x/tokenization/ai_test/unit/msg_handlers	0.168s
ok  	github.com/bitbadges/bitbadgeschain/x/tokenization/ai_test/unit/queries	0.124s
ok  	github.com/bitbadges/bitbadgeschain/x/tokenization/ai_test/unit/types	0.086s
ok  	github.com/bitbadges/bitbadgeschain/x/tokenization/ai_test/validation	0.087s
ok  	github.com/bitbadges/bitbadgeschain/x/tokenization/ai_test/validation/messages	0.105s
ok  	github.com/bitbadges/bitbadgeschain/x/tokenization/approval_criteria	0.092s
ok  	github.com/bitbadges/bitbadgeschain/x/tokenization/keeper	114.044s
ok  	github.com/bitbadges/bitbadgeschain/x/tokenization/module	0.080s
ok  	github.com/bitbadges/bitbadgeschain/x/tokenization/precompile/test/benchmarks	0.090s
ok  	github.com/bitbadges/bitbadgeschain/x/tokenization/precompile/test/compliance	0.103s
ok  	github.com/bitbadges/bitbadgeschain/x/tokenization/precompile/test/e2e	0.279s
ok  	github.com/bitbadges/bitbadgeschain/x/tokenization/precompile/test/edge_cases	0.100s
ok  	github.com/bitbadges/bitbadgeschain/x/tokenization/precompile/test/fuzz	0.078s
ok  	github.com/bitbadges/bitbadgeschain/x/tokenization/precompile/test/integration	8.872s
ok  	github.com/bitbadges/bitbadgeschain/x/tokenization/precompile/test/unit	0.108s
ok  	github.com/bitbadges/bitbadgeschain/x/tokenization/simulation	0.090s
ok  	github.com/bitbadges/bitbadgeschain/x/tokenization/types	0.556s
```

## Notes on existing state

- Existing approvals on chain that already have out-of-bound values are not cleaned up by this PR. If any exist from v29 onwards, they will continue to block transfers through that approval — but now with a clean error message rather than a panic. A separate migration / sweep at the next upgrade could purge them if needed (see the backlog ticket's Notes section).
- This fix is narrow to AltTimeChecks. The same class of issue (unbounded `sdkmath.Uint` passed to narrowing conversions) exists elsewhere — notably `IncrementOwnershipTimesBy` / `IncrementTokenIdsBy` and `DelayAfterQuorum`. Those are tracked separately.

---

Security-related. Does not disclose an in-the-wild exploitable chain-halt bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)