### PR TITLE
fix(tokenization): pool->intermediate swaps rejected by prioritization filter

### DIFF
--- a/x/tokenization/keeper/approved_transfers_error_helpers.go
+++ b/x/tokenization/keeper/approved_transfers_error_helpers.go
@@ -133,11 +133,35 @@ func buildPotentialErrorsString(
 	potentialErrorsStr += ")"
 
 	if len(approvalIdxsChecked) == 0 && len(unfilteredApprovals) > 0 {
-		skippedIds := []string{}
-		for _, a := range unfilteredApprovals {
-			skippedIds = append(skippedIds, fmt.Sprintf("%q", a.ApprovalId))
+		// Distinguish approvals that were dropped by the priority filter (genuinely "require
+		// prioritization") from those that survived the filter but failed address/time checks.
+		// The old code lumped both under "require prioritization", which was misleading when
+		// e.g. a Transfer set OnlyCheckPrioritized*Approvals=true and filtered out an otherwise-
+		// matching auto-scannable approval.
+		postFilterIds := make(map[string]struct{}, len(approvals))
+		for _, a := range approvals {
+			if a != nil {
+				postFilterIds[a.ApprovalId] = struct{}{}
+			}
 		}
-		potentialErrorsStr += fmt.Sprintf(". Approvals not checked (require prioritization): [%s]", strings.Join(skippedIds, ", "))
+		filteredOut := []string{}
+		survivedButFailed := []string{}
+		for _, a := range unfilteredApprovals {
+			if a == nil {
+				continue
+			}
+			if _, kept := postFilterIds[a.ApprovalId]; kept {
+				survivedButFailed = append(survivedButFailed, fmt.Sprintf("%q", a.ApprovalId))
+			} else {
+				filteredOut = append(filteredOut, fmt.Sprintf("%q", a.ApprovalId))
+			}
+		}
+		if len(filteredOut) > 0 {
+			potentialErrorsStr += fmt.Sprintf(". Approvals dropped by prioritization filter (set OnlyCheckPrioritized*Approvals or missing from PrioritizedApprovals): [%s]", strings.Join(filteredOut, ", "))
+		}
+		if len(survivedButFailed) > 0 {
+			potentialErrorsStr += fmt.Sprintf(". Approvals checked but failed address/time match: [%s]", strings.Join(survivedButFailed, ", "))
+		}
 	}
 
 	// Try to be smart about error logs. If we only checked one approval via auto-scan, we can just log the errors for that approval

--- a/x/tokenization/keeper/pool_integration.go
+++ b/x/tokenization/keeper/pool_integration.go
@@ -232,9 +232,11 @@ func (k *Keeper) SendNativeTokensFromAddressWithPoolApprovals(ctx sdk.Context, f
 		return sdkerrors.Wrapf(err, "failed to create one-time approval: %s", approvalId)
 	}
 
-	// Important: We should only allow auto-scanned approvals here
-	//            Anything prioritized is potentially unsafe if we are using an IBC hook (where we cannot trust the sender)
-	// The one-time outgoing approval is safe because it uses a unique ID and version
+	// Restrict the outgoing (pool) side to only the one-time prioritized approval we just set
+	// up — the pool cannot be drained via any other outgoing approval it happens to have.
+	// The incoming (recipient) side is intentionally left unrestricted so normal auto-scannable
+	// approvals (including the synthetic "all-incoming" for intermediate swap addresses with
+	// AutoApproveAllIncomingTransfers=true) can satisfy the transfer.
 	msg := &tokenizationtypes.MsgTransferTokens{
 		Creator:      recipientAddress,
 		CollectionId: collection.CollectionId,
@@ -251,7 +253,7 @@ func (k *Keeper) SendNativeTokensFromAddressWithPoolApprovals(ctx sdk.Context, f
 						Version:         approvalVersion,
 					},
 				},
-				OnlyCheckPrioritizedIncomingApprovals: true,
+				OnlyCheckPrioritizedOutgoingApprovals: true,
 			},
 		},
 	}

--- a/x/tokenization/keeper/pool_integration_test.go
+++ b/x/tokenization/keeper/pool_integration_test.go
@@ -342,3 +342,136 @@ func (suite *PoolIntegrationTestSuite) TestGetBalancesToTransferWithAlias_Invali
 	suite.Require().Error(err)
 }
 
+// createCollectionWithAliasPathNoIncomingOverride builds a collection with alias paths but,
+// unlike createCollectionWithAliasPath, leaves OverridesToIncomingApprovals=false so the
+// recipient's incoming approvals are actually exercised on transfer.
+func (suite *PoolIntegrationTestSuite) createCollectionWithAliasPathNoIncomingOverride(creator string, denom string) (*types.TokenCollection, string, error) {
+	wctx := sdk.WrapSDKContext(suite.ctx)
+
+	collectionsToCreate := GetTransferableCollectionToCreateAllMintedToCreator(creator)
+	collectionsToCreate[0].AliasPathsToAdd = []*types.AliasPathAddObject{
+		{
+			Denom: denom,
+			Conversion: &types.ConversionWithoutDenom{
+				SideA: &types.ConversionSideA{Amount: sdkmath.NewUint(1)},
+				SideB: []*types.Balance{
+					{
+						Amount:         sdkmath.NewUint(1),
+						OwnershipTimes: GetFullUintRanges(),
+						TokenIds:       GetOneUintRange(),
+					},
+				},
+			},
+			Symbol:     "SWAPHOOK",
+			DenomUnits: []*types.DenomUnit{{Decimals: sdkmath.NewUint(6), Symbol: denom, IsDefaultDisplay: true}},
+		},
+	}
+	collectionsToCreate[0].CollectionApprovals = append(collectionsToCreate[0].CollectionApprovals, &types.CollectionApproval{
+		ApprovalId:        "wrapper-transfer",
+		TransferTimes:     GetFullUintRanges(),
+		OwnershipTimes:    GetFullUintRanges(),
+		TokenIds:          GetOneUintRange(),
+		FromListId:        "AllWithoutMint",
+		ToListId:          "AllWithoutMint",
+		InitiatedByListId: "AllWithoutMint",
+		ApprovalCriteria: &types.ApprovalCriteria{
+			OverridesFromOutgoingApprovals: true,
+			// Deliberately NOT setting OverridesToIncomingApprovals — we want the recipient's
+			// incoming approvals to run, which is how the swap-and-action-hooks flow actually
+			// behaves for intermediate addresses.
+		},
+	})
+
+	if err := CreateCollections(&suite.TestSuite, wctx, collectionsToCreate); err != nil {
+		return nil, "", err
+	}
+
+	collection, err := GetCollection(&suite.TestSuite, wctx, sdkmath.NewUint(1))
+	if err != nil {
+		return nil, "", err
+	}
+
+	wrapperDenom := keeper.AliasDenomPrefix + collection.CollectionId.String() + ":" + denom
+	return collection, wrapperDenom, nil
+}
+
+// TestSendNativeTokensFromAddressWithPoolApprovals_RecipientUsesAutoApproveAllIncoming simulates
+// the swap-and-action-hooks flow where a pool sends wrapped tokens to an intermediate address
+// that was just flagged with AutoApproveAllIncomingTransfers=true (e.g., an IBC-derived swap
+// recipient). The synthetic "all-incoming" approval must satisfy the transfer.
+//
+// Regression: previously this path set OnlyCheckPrioritizedIncomingApprovals=true on the
+// generated transfer, which dropped the synthetic (and every other non-prioritized incoming
+// approval) from the filter, causing "incoming approvals not satisfied" even though the
+// recipient had explicitly opted into receiving everything.
+func (suite *PoolIntegrationTestSuite) TestSendNativeTokensFromAddressWithPoolApprovals_RecipientUsesAutoApproveAllIncoming() {
+	wctx := sdk.WrapSDKContext(suite.ctx)
+
+	collection, wrapperDenom, err := suite.createCollectionWithAliasPathNoIncomingOverride(bob, "swaphooktest")
+	suite.Require().NoError(err)
+
+	// Mint tokens to bob (stand-in for the pool's pre-funded source).
+	err = TransferTokens(&suite.TestSuite, wctx, &types.MsgTransferTokens{
+		Creator:      bob,
+		CollectionId: sdkmath.NewUint(1),
+		Transfers: []*types.Transfer{
+			{
+				From:        "Mint",
+				ToAddresses: []string{bob},
+				Balances: []*types.Balance{
+					{
+						Amount:         sdkmath.NewUint(10),
+						TokenIds:       GetOneUintRange(),
+						OwnershipTimes: GetFullUintRanges(),
+					},
+				},
+				PrioritizedApprovals: []*types.ApprovalIdentifierDetails{
+					{
+						ApprovalId:      "mint-test",
+						ApprovalLevel:   "collection",
+						ApproverAddress: "",
+						Version:         sdkmath.NewUint(0),
+					},
+				},
+			},
+		},
+	})
+	suite.Require().NoError(err)
+
+	// Recipient = alice, standing in for the IBC-derived intermediate swap address.
+	// Simulate swap-and-action-hooks flagging the intermediate for auto-approve.
+	err = UpdateUserApprovals(&suite.TestSuite, wctx, &types.MsgUpdateUserApprovals{
+		Creator:                               alice,
+		CollectionId:                          sdkmath.NewUint(1),
+		UpdateAutoApproveAllIncomingTransfers: true,
+		AutoApproveAllIncomingTransfers:       true,
+	})
+	suite.Require().NoError(err)
+
+	aliceBalanceBefore, err := GetUserBalance(&suite.TestSuite, wctx, collection.CollectionId, alice)
+	suite.Require().NoError(err)
+	suite.Require().True(aliceBalanceBefore.AutoApproveAllIncomingTransfers)
+
+	// The call under test — mirrors what SendCoinsFromPoolWithAliasRouting invokes after the
+	// gamm swap finishes and needs to move tokenized output to the recipient.
+	err = suite.app.TokenizationKeeper.SendNativeTokensFromAddressWithPoolApprovals(
+		suite.ctx,
+		bob,   // fromAddress (pool stand-in)
+		alice, // recipient (intermediate swap address)
+		wrapperDenom,
+		sdkmath.NewUint(1),
+	)
+	suite.Require().NoError(err, "pool->intermediate transfer must succeed when recipient has AutoApproveAllIncomingTransfers")
+
+	// Sanity: alice received the tokens and the one-time outgoing approval was cleaned up on bob.
+	aliceBalanceAfter, err := GetUserBalance(&suite.TestSuite, wctx, collection.CollectionId, alice)
+	suite.Require().NoError(err)
+	suite.Require().True(len(aliceBalanceAfter.Balances) > 0, "recipient should have received tokens")
+
+	bobBalanceAfter, err := GetUserBalance(&suite.TestSuite, wctx, collection.CollectionId, bob)
+	suite.Require().NoError(err)
+	for _, ap := range bobBalanceAfter.OutgoingApprovals {
+		suite.Require().NotContains(ap.ApprovalId, "one-time-outgoing-", "one-time approval must be deleted after transfer")
+	}
+}
+


### PR DESCRIPTION
## Summary

Root cause of the swap-and-action-hooks failures like:

```
swap-and-action-hooks: swap failed: ... incoming approvals not satisfied:
attempting to transfer ID 1 from bb1upu02ml... to bb1q8nfq... initiated by bb1q8nfq...
- auto-scan failed (checked 0 potentially matching approval).
Approvals not checked (require prioritization): ["all-incoming"]
```

Two bugs — one is the actual cause, the other is the misleading message that led us down the wrong trail.

### 1. The actual bug (`pool_integration.go:254`)

`SendNativeTokensFromAddressWithPoolApprovals` is called when a gamm pool ships tokenized output to a recipient (the tail end of an IBC swap hook, after `swap-and-action-hooks` flags the intermediate address with `AutoApproveAllIncomingTransfers=true`).

It sets up a one-time **outgoing** approval for the pool address to authorize the send, but the transfer was built with:

```go
OnlyCheckPrioritizedIncomingApprovals: true
```

That flag applies to the wrong side. Since nothing is ever prioritized on the incoming side, `FilterApprovalsWithPrioritizedHandling` (`approved_transfers_utils.go:152`) sets `approvals = prioritizedTransfers` → `[]` and drops every incoming approval before the auto-scannable check runs — including the synthetic `all-incoming` that the just-set `AutoApproveAllIncomingTransfers` flag is supposed to produce.

Fix: switch to `OnlyCheckPrioritizedOutgoingApprovals: true`, which matches the `ApprovalLevel: "outgoing"` of the one-time approval we're actually gating on. The pool's outgoing side is locked down to just the one-time approval; the recipient's incoming side goes through the normal auto-scannable path.

### 2. The misleading error message (`approved_transfers_error_helpers.go`)

`buildPotentialErrorsString` printed `Approvals not checked (require prioritization): [...]` whenever `approvalIdxsChecked == 0`, dumping **every** approval in the unfiltered list with no regard for why each one failed. An approval that survived the filter but failed address/time matching got the same "require prioritization" label as one that was actually dropped by the filter.

Now it diffs `unfilteredApprovals` against the post-filter `approvals` set and produces two distinct buckets:

- `Approvals dropped by prioritization filter (set OnlyCheckPrioritized*Approvals or missing from PrioritizedApprovals): [...]`
- `Approvals checked but failed address/time match: [...]`

## Test plan

- [x] New regression test `TestSendNativeTokensFromAddressWithPoolApprovals_RecipientUsesAutoApproveAllIncoming` reproduces the exact production error when run against the pre-fix code:
  > `auto-scan failed (checked 0 potentially matching approval). Approvals dropped by prioritization filter (...): ["all-incoming", "test"]`
- [x] Same test passes after the fix
- [x] Full `x/tokenization/...` suite passes with `-tags=test`
- [x] `x/custom-hooks/...` suite passes

## Notes for review

- The existing `createCollectionWithAliasPath` helper adds `OverridesToIncomingApprovals: true`, which masks this bug by bypassing the incoming check entirely. Added `createCollectionWithAliasPathNoIncomingOverride` so the regression test actually exercises the incoming path.
- There's a separate, deeper question of whether auto-scannable approvals should always survive `onlyCheckPrioritized=true` (the comment at `approved_transfers_utils.go:60` arguably implies they should). Not changing that here — it's a semantics change that could affect anyone intentionally setting `OnlyCheckPrioritized*Approvals=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)