### PR TITLE
fix(tokenization): MsgCreateCollection silently drops ValidTokenIds

### DIFF
--- a/x/tokenization/keeper/msg_server_create_collection.go
+++ b/x/tokenization/keeper/msg_server_create_collection.go
@@ -30,6 +30,7 @@ func (k msgServer) CreateCollection(goCtx context.Context, msg *types.MsgCreateC
 		DefaultBalances: msg.DefaultBalances,
 
 		// Applicable to creations and updates
+		UpdateValidTokenIds:         true,
 		ValidTokenIds:               msg.ValidTokenIds,
 		UpdateCollectionPermissions: true,
 		CollectionPermissions:       msg.CollectionPermissions,

--- a/x/tokenization/keeper/msg_server_new_collection_test.go
+++ b/x/tokenization/keeper/msg_server_new_collection_test.go
@@ -95,6 +95,32 @@ func (suite *TestSuite) TestNewCollectionDuplicateTokenIds() {
 	suite.Require().Error(err, "Error creating token: %s")
 }
 
+// Regression: MsgCreateCollection wraps MsgUniversalUpdateCollection and must
+// set UpdateValidTokenIds=true so ValidTokenIds persists to chain state.
+func (suite *TestSuite) TestCreateCollectionPersistsValidTokenIds() {
+	wctx := sdk.WrapSDKContext(suite.ctx)
+
+	validTokenIds := []*types.UintRange{{Start: sdkmath.NewUint(1), End: sdkmath.NewUint(1)}}
+
+	res, err := suite.msgServer.CreateCollection(wctx, &types.MsgCreateCollection{
+		Creator:       bob,
+		ValidTokenIds: validTokenIds,
+		CollectionPermissions: &types.CollectionPermissions{
+			CanUpdateValidTokenIds: []*types.TokenIdsActionPermission{{PermanentlyPermittedTimes: GetFullUintRanges()}},
+		},
+		DefaultBalances: &types.UserBalanceStore{
+			AutoApproveSelfInitiatedOutgoingTransfers: true,
+			AutoApproveSelfInitiatedIncomingTransfers: true,
+		},
+	})
+	suite.Require().NoError(err, "CreateCollection failed")
+	suite.Require().NotNil(res)
+
+	collection, err := GetCollection(suite, wctx, res.CollectionId)
+	suite.Require().NoError(err)
+	AssertUintRangesEqual(suite, validTokenIds, collection.ValidTokenIds)
+}
+
 func (suite *TestSuite) TestNewCollectionNonSequentialTokenIds() {
 	wctx := sdk.WrapSDKContext(suite.ctx)
 


### PR DESCRIPTION
## Summary
- `CreateCollection` msg server wraps `MsgUniversalUpdateCollection` but omits `UpdateValidTokenIds: true`, so the universal handler never ingests `ValidTokenIds` for `MsgCreateCollection` txs. Every new collection created via this path landed with empty `validTokenIds` on chain.
- Every other `Update*` flag was set correctly; `UpdateValidTokenIds` was the lone gap.
- Bug escaped tests because no existing keeper test exercises the `MsgCreateCollection` path directly — all integration helpers (`CreateCollections`) route through `UniversalUpdateCollection`.
- Added a regression test that fails pre-fix (asserts expected `validTokenIds` == on-chain state).

## Repro (pre-fix)
Submit a `MsgCreateCollection` with `validTokenIds: [{start:"1",end:"1"}]`. On chain, `collection.validTokenIds` is `[]`. Tokens 1..N are un-mintable; the collection is a brick.

Real-world hit: testnet collection 83 was submitted via `/dev/broadcast → MsgCreateCollection` with non-empty `validTokenIds`; on-chain state shows `validTokenIds: []`. Context: bitbadges-autopilot ticket #0336.

## Test plan
- [x] `go test -tags=test -run TestTokenizationKeeperTestSuite/TestCreateCollectionPersistsValidTokenIds ./x/tokenization/keeper/` — passes post-fix, fails pre-fix (verified by temporarily reverting the one-liner)
- [x] Full `./x/tokenization/keeper/` suite passes (`-tags=test`, 133s)
- [ ] Confirm existing testnet collection 83 can't be retroactively fixed (abandoned; separate from this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)