### PR TITLE
feat(tokenization): inclusive protocol fees (#0335)

### DIFF
--- a/x/tokenization/keeper/coin_transfers.go
+++ b/x/tokenization/keeper/coin_transfers.go
@@ -8,10 +8,16 @@ import (
 	sdkerrors "cosmossdk.io/errors"
 	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 )
 
 const (
 	RoyaltyDivisor = 10000
+	// ProtocolFeeDenominator is the divisor for the inclusive protocol fee
+	// (0.1% = amount / 1000). Applied per-coin before royalty/recipient split,
+	// so the payer sends exactly the quoted amount.
+	ProtocolFeeDenominator = 1000
 )
 
 // formatDenomForDisplay formats a denom for display in error messages
@@ -189,10 +195,28 @@ func (k Keeper) ExecuteCoinTransfers(
 		}
 
 		for _, coin := range coinsToTransfer {
+			// Inclusive protocol fee: taken out of the payer's gross amount first,
+			// so the payer sends exactly coin.Amount (not amount + fee on top).
 			coinAmountUint := sdkmath.NewUintFromBigInt(coin.Amount.BigInt())
+			protocolFeeUint := coinAmountUint.Quo(sdkmath.NewUint(ProtocolFeeDenominator))
+			protocolFeeInt := sdkmath.NewIntFromBigInt(protocolFeeUint.BigInt())
+
 			royaltyAmountUint := coinAmountUint.Mul(royaltyPercentage).Quo(sdkmath.NewUint(RoyaltyDivisor))
 			royaltyAmountInt := sdkmath.NewIntFromBigInt(royaltyAmountUint.BigInt())
-			remainingAmount := coin.Amount.Sub(royaltyAmountInt)
+
+			// Both fees come off the gross. With royalty capped at 100% the two could add
+			// to more than gross; reject rather than silently shortchange the recipient.
+			if protocolFeeInt.Add(royaltyAmountInt).GT(coin.Amount) {
+				detErrMsg := fmt.Sprintf("royalty %s + protocol fee %s exceeds transfer amount %s for denom %s", royaltyAmountInt.String(), protocolFeeInt.String(), coin.Amount.String(), formatDenomForDisplay(coin.Denom))
+				return detErrMsg, sdkerrors.Wrap(types.ErrInvalidRequest, detErrMsg)
+			}
+
+			remainingAmount := coin.Amount.Sub(royaltyAmountInt).Sub(protocolFeeInt)
+
+			if err := k.sendProtocolFee(ctx, coin, protocolFeeInt, fromAddressAcc, coinTransfersUsed); err != nil {
+				detErrMsg := fmt.Sprintf("insufficient %s balance to cover protocol fee", formatDenomForDisplay(coin.Denom))
+				return detErrMsg, sdkerrors.Wrap(types.ErrUnderflow, err.Error())
+			}
 
 			err := k.sendCoinWithRoyalty(
 				ctx,
@@ -217,6 +241,35 @@ func (k Keeper) ExecuteCoinTransfers(
 	}
 
 	return "", nil
+}
+
+// sendProtocolFee routes the inclusive protocol fee from the payer to the community pool.
+// No-op when the fee rounds to zero (amounts below ProtocolFeeDenominator).
+func (k Keeper) sendProtocolFee(
+	ctx sdk.Context,
+	coin *sdk.Coin,
+	feeAmount sdkmath.Int,
+	fromAddressAcc sdk.AccAddress,
+	coinTransfersUsed *[]CoinTransfers,
+) error {
+	if feeAmount.IsZero() {
+		return nil
+	}
+
+	feeCoins := sdk.NewCoins(sdk.NewCoin(coin.Denom, feeAmount))
+	if err := k.sendManagerKeeper.FundCommunityPoolWithAliasRouting(ctx, fromAddressAcc, feeCoins); err != nil {
+		return sdkerrors.Wrapf(err, "error funding community pool with protocol fee: %s", feeCoins)
+	}
+
+	*coinTransfersUsed = append(*coinTransfersUsed, CoinTransfers{
+		From:          fromAddressAcc.String(),
+		To:            authtypes.NewModuleAddress(distrtypes.ModuleName).String(),
+		Amount:        feeAmount.String(),
+		Denom:         coin.Denom,
+		IsProtocolFee: true,
+	})
+
+	return nil
 }
 
 // sendCoinWithRoyalty handles sending a coin with royalty deduction

--- a/x/tokenization/keeper/inclusive_protocol_fees_test.go
+++ b/x/tokenization/keeper/inclusive_protocol_fees_test.go
@@ -1,0 +1,305 @@
+package keeper_test
+
+import (
+	"github.com/bitbadges/bitbadgeschain/x/tokenization/types"
+
+	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// Inclusive protocol fee: the payer sends exactly the coin transfer amount.
+// The chain skims 0.1% for the community pool out of that amount (not on top).
+// See backlog #0335.
+
+// configureSingleCoinTransferApproval wires up a mint approval whose coinTransfer
+// sends `amount` of ubadge from bob (creator) to alice on behalf of a mint.
+func (suite *TestSuite) configureSingleCoinTransferApproval(amount sdkmath.Int) {
+	wctx := sdk.WrapSDKContext(suite.ctx)
+	collectionsToCreate := GetCollectionsToCreate()
+	collectionsToCreate[0].CollectionApprovals[0].FromListId = "Mint"
+	collectionsToCreate[0].CollectionApprovals[0].ApprovalCriteria.CoinTransfers = []*types.CoinTransfer{
+		{
+			To: alice,
+			Coins: []*sdk.Coin{
+				{Amount: amount, Denom: "ubadge"},
+			},
+		},
+	}
+	collectionsToCreate[0].CollectionApprovals[0].ApprovalCriteria.OverridesFromOutgoingApprovals = true
+	collectionsToCreate[0].CollectionApprovals[0].ApprovalCriteria.OverridesToIncomingApprovals = true
+
+	err := CreateCollections(suite, wctx, collectionsToCreate)
+	suite.Require().Nil(err, "error creating collection")
+}
+
+func (suite *TestSuite) runMintTransferForCoinTransferApproval() error {
+	wctx := sdk.WrapSDKContext(suite.ctx)
+	return TransferTokens(suite, wctx, &types.MsgTransferTokens{
+		Creator:      bob,
+		CollectionId: sdkmath.NewUint(1),
+		Transfers: []*types.Transfer{
+			{
+				From:        "Mint",
+				ToAddresses: []string{alice},
+				Balances: []*types.Balance{
+					{
+						OwnershipTimes: GetFullUintRanges(),
+						TokenIds:       GetFullUintRanges(),
+						Amount:         sdkmath.NewUint(1),
+					},
+				},
+				PrioritizedApprovals: GetDefaultPrioritizedApprovals(suite.ctx, suite.app.TokenizationKeeper, sdkmath.NewUint(1)),
+			},
+		},
+	})
+}
+
+// TestInclusiveProtocolFeeDebitsPayerExactly verifies the payer is debited exactly
+// the coin transfer amount (not amount + fee). The fee is carved out of the payment.
+func (suite *TestSuite) TestInclusiveProtocolFeeDebitsPayerExactly() {
+	const gross int64 = 10_000 // 0.1% = 10 → non-zero fee
+	const expectedFee int64 = 10
+
+	suite.configureSingleCoinTransferApproval(sdkmath.NewInt(gross))
+
+	bobAddr := sdk.MustAccAddressFromBech32(bob)
+	aliceAddr := sdk.MustAccAddressFromBech32(alice)
+	poolAddr := suite.app.DistrKeeper.GetDistributionAccount(suite.ctx).GetAddress()
+
+	bobBefore := suite.app.BankKeeper.GetBalance(suite.ctx, bobAddr, "ubadge").Amount
+	aliceBefore := suite.app.BankKeeper.GetBalance(suite.ctx, aliceAddr, "ubadge").Amount
+	poolBefore := suite.app.BankKeeper.GetBalance(suite.ctx, poolAddr, "ubadge").Amount
+
+	err := suite.runMintTransferForCoinTransferApproval()
+	suite.Require().Nil(err, "transfer should succeed")
+
+	bobAfter := suite.app.BankKeeper.GetBalance(suite.ctx, bobAddr, "ubadge").Amount
+	aliceAfter := suite.app.BankKeeper.GetBalance(suite.ctx, aliceAddr, "ubadge").Amount
+	poolAfter := suite.app.BankKeeper.GetBalance(suite.ctx, poolAddr, "ubadge").Amount
+
+	// Payer sends exactly gross — not gross + fee.
+	suite.Require().Equal(
+		sdkmath.NewInt(gross),
+		bobBefore.Sub(bobAfter),
+		"payer should be debited exactly the coin transfer amount (inclusive fee)",
+	)
+
+	// Recipient gets gross - fee.
+	suite.Require().Equal(
+		sdkmath.NewInt(gross-expectedFee),
+		aliceAfter.Sub(aliceBefore),
+		"recipient should receive gross minus the inclusive protocol fee",
+	)
+
+	// Community pool received the fee.
+	suite.Require().Equal(
+		sdkmath.NewInt(expectedFee),
+		poolAfter.Sub(poolBefore),
+		"community pool should receive the protocol fee",
+	)
+}
+
+// TestInclusiveProtocolFeeRoundsToZero verifies small amounts below the fee
+// denominator (1000 ubadge) pay no fee — matches the previous behavior at
+// the low end, so existing integrations with small amounts are unaffected.
+func (suite *TestSuite) TestInclusiveProtocolFeeRoundsToZero() {
+	const gross int64 = 100 // 0.1% = 0.1 → rounds down to 0
+
+	suite.configureSingleCoinTransferApproval(sdkmath.NewInt(gross))
+
+	bobAddr := sdk.MustAccAddressFromBech32(bob)
+	aliceAddr := sdk.MustAccAddressFromBech32(alice)
+	poolAddr := suite.app.DistrKeeper.GetDistributionAccount(suite.ctx).GetAddress()
+
+	bobBefore := suite.app.BankKeeper.GetBalance(suite.ctx, bobAddr, "ubadge").Amount
+	aliceBefore := suite.app.BankKeeper.GetBalance(suite.ctx, aliceAddr, "ubadge").Amount
+	poolBefore := suite.app.BankKeeper.GetBalance(suite.ctx, poolAddr, "ubadge").Amount
+
+	err := suite.runMintTransferForCoinTransferApproval()
+	suite.Require().Nil(err, "transfer should succeed")
+
+	bobAfter := suite.app.BankKeeper.GetBalance(suite.ctx, bobAddr, "ubadge").Amount
+	aliceAfter := suite.app.BankKeeper.GetBalance(suite.ctx, aliceAddr, "ubadge").Amount
+	poolAfter := suite.app.BankKeeper.GetBalance(suite.ctx, poolAddr, "ubadge").Amount
+
+	suite.Require().Equal(sdkmath.NewInt(gross), bobBefore.Sub(bobAfter), "payer debited gross")
+	suite.Require().Equal(sdkmath.NewInt(gross), aliceAfter.Sub(aliceBefore), "recipient gets full amount when fee rounds to zero")
+	suite.Require().Equal(sdkmath.ZeroInt(), poolAfter.Sub(poolBefore), "no fee routed to community pool for sub-denominator amounts")
+}
+
+// TestInclusiveProtocolFeeWithRoyalty verifies royalty + protocol fee are both
+// carved out of the gross payment. The payer still sends exactly the quoted
+// amount, and the recipient gets gross - royalty - fee.
+func (suite *TestSuite) TestInclusiveProtocolFeeWithRoyalty() {
+	const gross int64 = 10_000
+	const royaltyBps = 1000 // 10%
+	const expectedFee int64 = 10
+	const expectedRoyalty int64 = 1000
+	const expectedRecipient int64 = gross - expectedFee - expectedRoyalty
+
+	collectionsToCreate := GetTransferableCollectionToCreateAllMintedToCreator(bob)
+	wctx := sdk.WrapSDKContext(suite.ctx)
+
+	collectionsToCreate[0].CollectionApprovals[1].ApprovalCriteria.UserApprovalSettings = &types.UserApprovalSettings{
+		UserRoyalties: &types.UserRoyalties{
+			Percentage:    sdkmath.NewUint(royaltyBps),
+			PayoutAddress: charlie,
+		},
+	}
+	suite.Require().Nil(CreateCollections(suite, wctx, collectionsToCreate), "error creating collection")
+
+	suite.Require().Nil(UpdateUserApprovals(suite, wctx, &types.MsgUpdateUserApprovals{
+		Creator:                 bob,
+		CollectionId:            sdkmath.NewUint(1),
+		UpdateOutgoingApprovals: true,
+		OutgoingApprovals: []*types.UserOutgoingApproval{
+			{
+				ToListId:          "AllWithoutMint",
+				InitiatedByListId: alice,
+				TransferTimes:     GetFullUintRanges(),
+				OwnershipTimes:    GetFullUintRanges(),
+				TokenIds:          []*types.UintRange{{Start: sdkmath.NewUint(1), End: sdkmath.NewUint(1)}},
+				ApprovalId:        "test",
+				ApprovalCriteria: &types.OutgoingApprovalCriteria{
+					MaxNumTransfers: &types.MaxNumTransfers{
+						OverallMaxNumTransfers: sdkmath.NewUint(1000),
+						AmountTrackerId:        "test-tracker",
+					},
+					ApprovalAmounts: &types.ApprovalAmounts{
+						PerFromAddressApprovalAmount: sdkmath.NewUint(1),
+						AmountTrackerId:              "test-tracker",
+					},
+					CoinTransfers: []*types.CoinTransfer{
+						{
+							To:                              alice,
+							OverrideFromWithApproverAddress: true, // bob (approver) pays
+							Coins: []*sdk.Coin{
+								{Amount: sdkmath.NewInt(gross), Denom: "ubadge"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}), "error updating user approvals")
+
+	bobAddr := sdk.MustAccAddressFromBech32(bob)
+	aliceAddr := sdk.MustAccAddressFromBech32(alice)
+	charlieAddr := sdk.MustAccAddressFromBech32(charlie)
+	poolAddr := suite.app.DistrKeeper.GetDistributionAccount(suite.ctx).GetAddress()
+
+	bobBefore := suite.app.BankKeeper.GetBalance(suite.ctx, bobAddr, "ubadge").Amount
+	aliceBefore := suite.app.BankKeeper.GetBalance(suite.ctx, aliceAddr, "ubadge").Amount
+	charlieBefore := suite.app.BankKeeper.GetBalance(suite.ctx, charlieAddr, "ubadge").Amount
+	poolBefore := suite.app.BankKeeper.GetBalance(suite.ctx, poolAddr, "ubadge").Amount
+
+	err := TransferTokens(suite, wctx, &types.MsgTransferTokens{
+		Creator:      alice,
+		CollectionId: sdkmath.NewUint(1),
+		Transfers: []*types.Transfer{
+			{
+				From:        bob,
+				ToAddresses: []string{alice},
+				Balances: []*types.Balance{
+					{
+						OwnershipTimes: GetFullUintRanges(),
+						TokenIds:       GetOneUintRange(),
+						Amount:         sdkmath.NewUint(1),
+					},
+				},
+				PrioritizedApprovals: []*types.ApprovalIdentifierDetails{
+					{ApprovalId: "test", ApprovalLevel: "collection", Version: sdkmath.NewUint(0)},
+					{ApprovalId: "test", ApprovalLevel: "outgoing", ApproverAddress: bob, Version: sdkmath.NewUint(1)},
+				},
+			},
+		},
+	})
+	suite.Require().Nil(err, "transfer should succeed")
+
+	bobAfter := suite.app.BankKeeper.GetBalance(suite.ctx, bobAddr, "ubadge").Amount
+	aliceAfter := suite.app.BankKeeper.GetBalance(suite.ctx, aliceAddr, "ubadge").Amount
+	charlieAfter := suite.app.BankKeeper.GetBalance(suite.ctx, charlieAddr, "ubadge").Amount
+	poolAfter := suite.app.BankKeeper.GetBalance(suite.ctx, poolAddr, "ubadge").Amount
+
+	suite.Require().Equal(sdkmath.NewInt(gross), bobBefore.Sub(bobAfter), "payer debited exactly gross")
+	suite.Require().Equal(sdkmath.NewInt(expectedRecipient), aliceAfter.Sub(aliceBefore), "recipient gets gross - fee - royalty")
+	suite.Require().Equal(sdkmath.NewInt(expectedRoyalty), charlieAfter.Sub(charlieBefore), "royalty payout receives full royalty % of gross")
+	suite.Require().Equal(sdkmath.NewInt(expectedFee), poolAfter.Sub(poolBefore), "community pool receives fee % of gross")
+}
+
+// TestInclusiveProtocolFeeRejectsRoyaltyPlusFeeOverflow verifies that a royalty
+// percentage high enough that royalty + fee > gross is rejected rather than
+// silently shortchanging the recipient by making them negative.
+func (suite *TestSuite) TestInclusiveProtocolFeeRejectsRoyaltyPlusFeeOverflow() {
+	const gross int64 = 10_000
+
+	collectionsToCreate := GetTransferableCollectionToCreateAllMintedToCreator(bob)
+	wctx := sdk.WrapSDKContext(suite.ctx)
+
+	// 100% royalty leaves zero for the recipient and 0.1% for the fee — overflow.
+	collectionsToCreate[0].CollectionApprovals[1].ApprovalCriteria.UserApprovalSettings = &types.UserApprovalSettings{
+		UserRoyalties: &types.UserRoyalties{
+			Percentage:    sdkmath.NewUint(10000), // 100%
+			PayoutAddress: charlie,
+		},
+	}
+	suite.Require().Nil(CreateCollections(suite, wctx, collectionsToCreate), "error creating collection")
+
+	suite.Require().Nil(UpdateUserApprovals(suite, wctx, &types.MsgUpdateUserApprovals{
+		Creator:                 bob,
+		CollectionId:            sdkmath.NewUint(1),
+		UpdateOutgoingApprovals: true,
+		OutgoingApprovals: []*types.UserOutgoingApproval{
+			{
+				ToListId:          "AllWithoutMint",
+				InitiatedByListId: alice,
+				TransferTimes:     GetFullUintRanges(),
+				OwnershipTimes:    GetFullUintRanges(),
+				TokenIds:          []*types.UintRange{{Start: sdkmath.NewUint(1), End: sdkmath.NewUint(1)}},
+				ApprovalId:        "test",
+				ApprovalCriteria: &types.OutgoingApprovalCriteria{
+					MaxNumTransfers: &types.MaxNumTransfers{
+						OverallMaxNumTransfers: sdkmath.NewUint(1000),
+						AmountTrackerId:        "test-tracker",
+					},
+					ApprovalAmounts: &types.ApprovalAmounts{
+						PerFromAddressApprovalAmount: sdkmath.NewUint(1),
+						AmountTrackerId:              "test-tracker",
+					},
+					CoinTransfers: []*types.CoinTransfer{
+						{
+							To:                              alice,
+							OverrideFromWithApproverAddress: true,
+							Coins: []*sdk.Coin{
+								{Amount: sdkmath.NewInt(gross), Denom: "ubadge"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}), "error updating user approvals")
+
+	err := TransferTokens(suite, wctx, &types.MsgTransferTokens{
+		Creator:      alice,
+		CollectionId: sdkmath.NewUint(1),
+		Transfers: []*types.Transfer{
+			{
+				From:        bob,
+				ToAddresses: []string{alice},
+				Balances: []*types.Balance{
+					{
+						OwnershipTimes: GetFullUintRanges(),
+						TokenIds:       GetOneUintRange(),
+						Amount:         sdkmath.NewUint(1),
+					},
+				},
+				PrioritizedApprovals: []*types.ApprovalIdentifierDetails{
+					{ApprovalId: "test", ApprovalLevel: "collection", Version: sdkmath.NewUint(0)},
+					{ApprovalId: "test", ApprovalLevel: "outgoing", ApproverAddress: bob, Version: sdkmath.NewUint(1)},
+				},
+			},
+		},
+	})
+	suite.Require().Error(err, "royalty + protocol fee exceeding gross should be rejected")
+}

--- a/x/tokenization/keeper/transfer_utils.go
+++ b/x/tokenization/keeper/transfer_utils.go
@@ -3,93 +3,12 @@ package keeper
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
 
 	"github.com/bitbadges/bitbadgeschain/x/tokenization/types"
 
-	sdkerrors "cosmossdk.io/errors"
 	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 )
-
-const (
-	// ProtocolFeeDenominator represents the denominator for protocol fee calculation (0.1% = 1/1000)
-	ProtocolFeeDenominator = 1000
-)
-
-// CalculateAndDistributeProtocolFees calculates protocol fees from coin transfers and distributes them
-// to the community pool
-func (k Keeper) CalculateAndDistributeProtocolFees(
-	ctx sdk.Context,
-	coinTransfers []CoinTransfers,
-	initiatedBy string,
-) ([]CoinTransfers, error) {
-	// Calculate protocol fees for all denoms (0.1% of each denom transferred)
-	protocolFees := sdk.NewCoins()
-	denomAmounts := make(map[string]sdkmath.Uint)
-
-	for _, coinTransfer := range coinTransfers {
-		amount := sdkmath.NewUintFromString(coinTransfer.Amount)
-		// initialize it if it doesn't exist
-		if _, ok := denomAmounts[coinTransfer.Denom]; !ok {
-			denomAmounts[coinTransfer.Denom] = sdkmath.NewUint(0)
-		}
-
-		denomAmounts[coinTransfer.Denom] = denomAmounts[coinTransfer.Denom].Add(amount)
-	}
-
-	// Sort map keys for deterministic iteration order
-	denoms := make([]string, 0, len(denomAmounts))
-	for denom := range denomAmounts {
-		denoms = append(denoms, denom)
-	}
-	sort.Strings(denoms)
-
-	for _, denom := range denoms {
-		totalAmount := denomAmounts[denom]
-		// 0.1% of the total amount for this denom
-		// Safety check to prevent division by zero
-		if ProtocolFeeDenominator == 0 {
-			return nil, sdkerrors.Wrapf(types.ErrInvalidRequest, "protocol fee denominator cannot be zero")
-		}
-		protocolFee := totalAmount.Quo(sdkmath.NewUint(ProtocolFeeDenominator))
-
-		// For other denoms, just use 0.1%
-		if !protocolFee.IsZero() {
-			protocolFees = protocolFees.Add(sdk.NewCoin(denom, sdkmath.NewIntFromBigInt(protocolFee.BigInt())))
-		}
-	}
-
-	fromAddressAcc, err := sdk.AccAddressFromBech32(initiatedBy)
-	if err != nil {
-		return nil, err
-	}
-
-	var protocolFeeTransfers []CoinTransfers
-
-	if !protocolFees.IsZero() {
-		// Send all fees to community pool using FundCommunityPoolWithAliasRouting to support wrapped badge denoms
-		err = k.sendManagerKeeper.FundCommunityPoolWithAliasRouting(ctx, fromAddressAcc, protocolFees)
-		if err != nil {
-			return nil, sdkerrors.Wrapf(err, "error funding community pool with protocol fees: %s", protocolFees)
-		}
-
-		// Add all protocol fees to coinTransfers for community pool
-		for _, protocolFee := range protocolFees {
-			protocolFeeTransfers = append(protocolFeeTransfers, CoinTransfers{
-				From:          initiatedBy,
-				To:            authtypes.NewModuleAddress(distrtypes.ModuleName).String(),
-				Amount:        protocolFee.Amount.String(),
-				Denom:         protocolFee.Denom,
-				IsProtocolFee: true,
-			})
-		}
-	}
-
-	return protocolFeeTransfers, nil
-}
 
 // HandleAutoDeletions processes auto-deletion logic for approvals after transfers
 func (k Keeper) HandleAutoDeletions(

--- a/x/tokenization/keeper/transfers.go
+++ b/x/tokenization/keeper/transfers.go
@@ -219,14 +219,8 @@ func (k Keeper) handleTransfersInternal(ctx sdk.Context, collection *types.Token
 				return err
 			}
 
-			// Calculate and distribute protocol fees
-			protocolFeeTransfers, err := k.CalculateAndDistributeProtocolFees(ctx, coinTransfers, initiatedBy)
-			if err != nil {
-				return err
-			}
-
-			// Add protocol fee transfers to the main coinTransfers slice
-			coinTransfers = append(coinTransfers, protocolFeeTransfers...)
+			// Protocol fees are now deducted inclusively inside ExecuteCoinTransfers and
+			// are already present in coinTransfers as entries with IsProtocolFee=true.
 
 			err = EmitUsedApprovalDetailsEvent(ctx, collection.CollectionId, transfer.From, to, initiatedBy, coinTransfers, approvalsUsed, transfer.Balances)
 			if err != nil {


### PR DESCRIPTION
## Summary

- Protocol fee moves from **on top of** the payment to **inclusive** — a 1 USDC transfer debits the payer exactly 1 USDC; recipient gets 0.999 USDC; community pool receives 0.001 USDC. Previously the payer was charged 1.001 USDC.
- Fee is deducted inline in `ExecuteCoinTransfers` before the royalty/recipient split, so the payer sends exactly the quoted amount.
- Royalty and protocol fee are both taken off gross. If royalty + fee > gross, the transfer is rejected instead of underflowing the recipient.
- `CalculateAndDistributeProtocolFees` is removed; the new `sendProtocolFee` helper routes the skim to the community pool while keeping `IsProtocolFee=true` entries in `coinTransfers` for event payloads.

### Why

Today's on-top fee causes round-number listings to charge odd amounts (1 USDC listing → 1.001 USDC debit). Every mainstream payment rail — card networks, Stripe, exchanges — quotes fees as a percentage *of* the transaction. This aligns us with that, predictably for users and for agents that want to pre-compute "how much leaves my balance."

### Behavior changes callers should know about

- **Payer debit changes.** The payer now sends exactly `coin.Amount`. Integrations that expected "recipient gets the exact coin amount" need to update their expectations — the recipient now gets `amount - royalty - fee`.
- **Fee payer follows the money.** Previously `initiatedBy` paid the fee regardless of overrides. Now whoever funds the transfer pays the fee — so approvals using `OverrideFromWithApproverAddress` charge the fee to the approver along with the coins. This is the consistent "inclusive" interpretation.
- **Royalty + fee overflow now rejected.** Previously a 100% royalty was allowed and the fee was additive. With inclusive fees, 100% royalty + any fee exceeds gross, so the transfer returns `ErrInvalidRequest` rather than underflowing.

### Open items not in this PR

- **Governance / upgrade note.** This is a consensus-breaking semantic change for anyone reconciling balances after a transfer. A proper upgrade handler + governance notice should ship before this hits mainnet — flagging here so review catches it.
- **Rounding.** Small amounts (< 1000 base units) still round to zero fee, same as before. Covered by the `TestInclusiveProtocolFeeRoundsToZero` test. No explicit floor policy introduced.
- **Gas fees (x/auth) are untouched** — this PR only covers protocol/app-level fees on token transfers, as scoped in #0335.

## Test plan

- [x] `go test -tags=test ./x/tokenization/keeper/... -run TestInclusiveProtocolFee` — 4/4 new tests pass:
  - `TestInclusiveProtocolFeeDebitsPayerExactly` — payer sends gross, recipient gets gross-fee, pool gets fee.
  - `TestInclusiveProtocolFeeWithRoyalty` — royalty + fee both come out of gross; recipient gets `gross - royalty - fee`.
  - `TestInclusiveProtocolFeeRoundsToZero` — sub-denominator amounts pay no fee (payer = recipient, pool unchanged).
  - `TestInclusiveProtocolFeeRejectsRoyaltyPlusFeeOverflow` — 100% royalty + fee is rejected.
- [x] Full `./x/tokenization/...` suite green except `TestGetKnownGoodCollectionId` in the simulation package, which fails identically on clean master (pre-existing, unrelated).
- [ ] Governance / upgrade handler (not in this PR — see open items).

Do **not** merge — review first.

Tracking: [backlog #0335](https://github.com/BitBadges/bitbadges-autopilot/blob/main/backlog/0335-chain-protocol-fees-inclusive-percentage-not-on-top.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)