### PR TITLE
install.sh: print exact PATH hint when bitbadges-cli isn't on PATH

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -213,8 +213,16 @@ main() {
 
   if command -v bitbadges-cli >/dev/null 2>&1; then
     echo "Successfully installed bitbadges-cli"
-  elif command -v bun >/dev/null 2>&1 || command -v npm >/dev/null 2>&1; then
-    echo "Note: bitbadges-cli installed but may not be in PATH. Check your global bin directory."
+  elif command -v bun >/dev/null 2>&1; then
+    bun_bin="$(bun pm bin -g 2>/dev/null || echo "$HOME/.bun/bin")"
+    echo "Note: bitbadges-cli installed via bun but may not be in PATH. Add it with:"
+    echo "  export PATH=\"${bun_bin}:\$PATH\""
+  elif command -v npm >/dev/null 2>&1; then
+    npm_prefix="$(npm config get prefix 2>/dev/null)"
+    if [ -n "$npm_prefix" ]; then
+      echo "Note: bitbadges-cli installed via npm but may not be in PATH. Add it with:"
+      echo "  export PATH=\"${npm_prefix}/bin:\$PATH\""
+    fi
   fi
 
   echo ""


### PR DESCRIPTION
## Summary

- After installing the SDK CLI (`bitbadges`) via bun or npm, detect the actual global bin directory and tell the user the exact `export PATH=...` line they need if `bitbadges-cli` didn't end up on their PATH.
- Replaces the previous generic hint (`Check your global bin directory`) which left users guessing.

## Why

Default install locations for the JS CLI are easy to miss:
- `bun install -g` lands in `~/.bun/bin`, which isn't on PATH unless the user has set it up.
- `npm install -g` honors `npm config get prefix`, which varies by setup (system, nvm, user prefix).

The chain binary install already prints a PATH hint for `/usr/local/bin`. This makes the JS CLI install equally helpful.

## Test plan

- [ ] Run `sh install.sh` on a system with bun installed but `~/.bun/bin` not on PATH — confirm the printed `export PATH=...` line is correct.
- [ ] Run with npm-only and a user-configured prefix — confirm the resolved prefix matches `npm config get prefix`/bin.
- [ ] Run with `bitbadges-cli` already on PATH — confirm the existing "Successfully installed" path still fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)