### PR TITLE
docs(install): switch to install.bitbadges.io short URL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,12 +173,12 @@ jobs:
 
             **One-liner:**
             ```bash
-            curl -fsSL https://raw.githubusercontent.com/BitBadges/bitbadgeschain/master/install.sh | sh
+            curl -fsSL https://install.bitbadges.io | sh
             ```
 
             **Testnet:**
             ```bash
-            curl -fsSL https://raw.githubusercontent.com/BitBadges/bitbadgeschain/master/install.sh | sh -s -- --testnet
+            curl -fsSL https://install.bitbadges.io | sh -s -- --testnet
             ```
 
             **SDK CLI:**

--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 # BitBadges Chain — One-liner installer
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/BitBadges/bitbadgeschain/master/install.sh | sh
-#   curl -fsSL https://raw.githubusercontent.com/BitBadges/bitbadgeschain/master/install.sh | sh -s -- --testnet
-#   curl -fsSL https://raw.githubusercontent.com/BitBadges/bitbadgeschain/master/install.sh | sh -s -- --version v28
+#   curl -fsSL https://install.bitbadges.io | sh
+#   curl -fsSL https://install.bitbadges.io | sh -s -- --testnet
+#   curl -fsSL https://install.bitbadges.io | sh -s -- --version v28
 #
 # Options:
 #   --testnet           Install testnet binary (default: mainnet)
@@ -42,7 +42,7 @@ while [ $# -gt 0 ]; do
     --help)
       echo "BitBadges Chain Installer"
       echo ""
-      echo "Usage: curl -fsSL https://raw.githubusercontent.com/BitBadges/bitbadgeschain/master/install.sh | sh"
+      echo "Usage: curl -fsSL https://install.bitbadges.io | sh"
       echo ""
       echo "Options:"
       echo "  --testnet           Install testnet binary (default: mainnet)"


### PR DESCRIPTION
## Summary

Replaces the long `raw.githubusercontent.com/BitBadges/bitbadgeschain/master/install.sh` URL with the new `install.bitbadges.io` Cloudflare-Worker-fronted short form in:

- `install.sh` header comments (3 lines)
- `.github/workflows/release.yml` — Install section of the GitHub Release body template (2 lines)

## Why

`install.bitbadges.io` is now live (Cloudflare Worker proxying the same `master/install.sh`). Anywhere users copy-paste an install command, the short URL is cleaner and decoupled from the repo path so a future rename/move doesn't break installs in the wild.

The Worker is a thin proxy — same trust surface, same content, 60s edge cache.

## Test plan

- [x] `curl -fsSL https://install.bitbadges.io | head -5` returns the install.sh banner.
- [ ] Verify GitHub Releases generated after merge show the short URL in their Install section.
- [ ] No remaining `raw.githubusercontent.com/.../install.sh` references in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)