### PR TITLE
fix(tokenization): persist next-dynamic-store-id when defaulting from 0

### DIFF
--- a/x/tokenization/keeper/msg_create_dynamic_store_test.go
+++ b/x/tokenization/keeper/msg_create_dynamic_store_test.go
@@ -3,6 +3,7 @@ package keeper_test
 import (
 	"testing"
 
+	sdkmath "cosmossdk.io/math"
 	"github.com/bitbadges/bitbadgeschain/x/tokenization/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
@@ -24,4 +25,35 @@ func TestKeeper_MsgCreateDynamicStore(t *testing.T) {
 	msg = types.NewMsgCreateDynamicStore("", false)
 	_, err = suite.msgServer.CreateDynamicStore(wctx, msg)
 	require.Error(t, err)
+}
+
+// Regression: when the next-id counter is zero (uninitialized), the first
+// create must assign id 1 AND advance the counter to 2 so the second create
+// gets id 2 — not id 1, which would silently overwrite the first store.
+func TestKeeper_MsgCreateDynamicStore_AssignsSequentialIdsFromZero(t *testing.T) {
+	suite := new(TestSuite)
+	suite.SetT(t)
+	suite.SetupTest()
+	ctx := suite.ctx
+	wctx := sdk.WrapSDKContext(ctx)
+
+	suite.app.TokenizationKeeper.SetNextDynamicStoreId(ctx, sdkmath.NewUint(0))
+
+	creator := "bb1jmjfq0tplp9tmx4v9uemw72y4d2wa5nrjmmk3q"
+
+	first, err := suite.msgServer.CreateDynamicStore(wctx, types.NewMsgCreateDynamicStore(creator, false))
+	require.NoError(t, err)
+	require.Equal(t, sdkmath.NewUint(1), first.StoreId)
+
+	second, err := suite.msgServer.CreateDynamicStore(wctx, types.NewMsgCreateDynamicStore(creator, false))
+	require.NoError(t, err)
+	require.Equal(t, sdkmath.NewUint(2), second.StoreId, "second create must get a new id, not clobber id 1")
+
+	third, err := suite.msgServer.CreateDynamicStore(wctx, types.NewMsgCreateDynamicStore(creator, false))
+	require.NoError(t, err)
+	require.Equal(t, sdkmath.NewUint(3), third.StoreId)
+
+	got, found := suite.app.TokenizationKeeper.GetDynamicStoreFromStore(ctx, sdkmath.NewUint(1))
+	require.True(t, found)
+	require.Equal(t, creator, got.CreatedBy)
 }

--- a/x/tokenization/keeper/msg_server_create_dynamic_store.go
+++ b/x/tokenization/keeper/msg_server_create_dynamic_store.go
@@ -17,10 +17,16 @@ func (k msgServer) CreateDynamicStore(goCtx context.Context, msg *types.MsgCreat
 		return nil, err
 	}
 
-	// Get the next dynamic store ID
+	// Get the next dynamic store ID. If the counter has never been written
+	// (chain launched without genesis init for this field, or upgraded onto a
+	// chain where it was missing), GetNextDynamicStoreId returns 0. Treat 0 as
+	// "use 1" AND persist it, so the subsequent IncrementNextDynamicStoreId
+	// lands at 2 instead of 1 — otherwise the second create would re-use id 1
+	// and silently overwrite the first store.
 	nextStoreId := k.GetNextDynamicStoreId(ctx)
-	if nextStoreId.Equal(sdkmath.NewUint(0)) {
+	if nextStoreId.IsZero() {
 		nextStoreId = sdkmath.NewUint(1)
+		k.SetNextDynamicStoreId(ctx, nextStoreId)
 	}
 
 	// Create the dynamic store


### PR DESCRIPTION
## Summary

The first ever `MsgCreateDynamicStore` on a chain reads the next-id counter (0), overrides it to 1 in-memory, but never persists the override. `IncrementNextDynamicStoreId` then increments the stored 0 to 1 — so the *second* create reads 1 and reuses it, silently clobbering the first store's `createdBy`, `uri`, `defaultValue`, and `globalEnabled`.

This already fired on `bitbadges-1` mainnet: a dynamic store created on 2026-02-28 was overwritten on 2026-04-26 when a different account submitted a fresh `MsgCreateDynamicStore`. Both got `store_id = 1`. The original creator's data is gone from chain state — anyone could have done this and effectively hijacked any approval criteria referencing store 1.

## Fix

`x/tokenization/keeper/msg_server_create_dynamic_store.go`: when overriding the counter from 0 to 1, also call `SetNextDynamicStoreId(1)` so the subsequent `IncrementNextDynamicStoreId` lands at 2 instead of 1.

This is a one-shot bug — once the counter is past 1, sequential allocation is correct. So the fix only matters for chains that haven't yet processed their second create. Mainnet is already past this point (counter is now at 4 after stores 1, 2, 3 were created today), but the fix prevents the same bug on every future chain launch / state reset.

## Test plan

- [x] New regression test `TestKeeper_MsgCreateDynamicStore_AssignsSequentialIdsFromZero` zeroes the counter and creates three stores back-to-back, asserting they receive ids 1, 2, 3 (with the previous code, it asserts the second create returns id 1 — clobber).
- [x] Verified the test fails on the unfixed code (`Error: expected 2, actual 1` with message "second create must get a new id, not clobber id 1").
- [x] Full keeper test suite passes (`go test -tags=test ./x/tokenization/keeper/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)