### PR TITLE
chain: agent-UX push — JSON Schema generator, bb alias, forwarder doc

### DIFF
--- a/cmd/bitbadgeschaind/cmd/cli_cmd.go
+++ b/cmd/bitbadgeschaind/cmd/cli_cmd.go
@@ -41,6 +41,7 @@ Where <subcommand> is any top-level bitbadges-cli subcommand:
   builder   — template builders, create-with-burner, burner wallets,
               review/verify/simulate/doctor, session tools, builder tools
   config    — manage ~/.bitbadges/config.json (base URL, API keys per network)
+  auth      — login/logout/status (ships via the SDK CLI release for #0360)
 
 New top-level bitbadges-cli subcommands automatically reach here without
 needing a Go alias — this wrapper is the single bridge between the chain

--- a/install.sh
+++ b/install.sh
@@ -186,8 +186,25 @@ main() {
     exit 1
   fi
 
+  # Friendly alias for agents and humans — `bb` is the entry point
+  # documented in docs.bitbadges.io/for-developers/cli/. Skip on Windows
+  # where symlinks need elevated perms and the `.exe` suffix is mandatory.
+  if [ "$os" != "windows" ]; then
+    if [ -w "$INSTALL_DIR" ] || [ "$USE_SUDO" = "no" ]; then
+      ln -sfn "${INSTALL_DIR}/${BINARY_NAME}" "${INSTALL_DIR}/bb"
+    elif [ "$USE_SUDO" = "auto" ] && command -v sudo >/dev/null 2>&1; then
+      sudo ln -sfn "${INSTALL_DIR}/${BINARY_NAME}" "${INSTALL_DIR}/bb"
+    else
+      echo "Error: ${INSTALL_DIR} is not writable for bb symlink. Run with sudo or use --install-dir." >&2
+      exit 1
+    fi
+  fi
+
   echo ""
   echo "Successfully installed bitbadgeschaind ${VERSION} (${NETWORK}) to ${INSTALL_DIR}/${BINARY_NAME}"
+  if [ "$os" != "windows" ]; then
+    echo "Linked ${INSTALL_DIR}/bb -> ${INSTALL_DIR}/${BINARY_NAME}"
+  fi
   echo ""
 
   # Verify


### PR DESCRIPTION
## Summary

Chain-side of the agent-UX push:

- **proto → JSON Schema generator** (#0352 autopilot): `scripts/gen-jsonschema.sh` driven by `buf generate` with the `chrusty/protoc-gen-jsonschema` plugin. Produces 65 `Msg*` request schemas (Draft-07) into `release-info/schemas/v1/` plus `index.json` listing all schemas + chain version + git SHA. Filename convention is `<package>.<MsgName>.json` (e.g. `tokenization.MsgCreateCollection.json`) because chain Msg names collide across modules. Each schema's `\$id` matches the docs-hosted URL `https://docs.bitbadges.io/schemas/v1/<package>.<MsgName>.json` so editors auto-validate when agents paste an example.
- **`bb` symlink** (#0355 autopilot): `install.sh` creates a friendly `bb` symlink alongside `bitbadgeschaind` after the binary is placed on PATH. Skipped on Windows. Matches existing install-script logic for `-w` / sudo / clear errors.
- **`cli_cmd.go` forwarder doc** (#0355 / #0360 autopilot): the `Long` doc on the `cli` subcommand now mentions the forthcoming `auth login/logout/status` flow that ships when the SDK release lands.

## Test plan

- [ ] `make proto-gen-jsonschema` regenerates `release-info/schemas/v1/` deterministically (idempotent rerun produces no diff)
- [ ] Schema files validate as JSON Schema Draft-07 (`ajv compile` clean)
- [ ] `bash install.sh` on Linux/macOS creates both `$INSTALL_DIR/bitbadgeschaind` and `$INSTALL_DIR/bb`; `bb --help` and `bitbadgeschaind --help` return identical content
- [ ] CI: schema generation step runs cleanly on the next release tag

## Notes for review

- **Plugin choice**: `chrusty/protoc-gen-jsonschema`. Mature, Go-installed, Draft-07 by default. Acceptable per user direction ("whatever is maintainable").
- **`.gitignore` adjustment**: `release-info/` was already gitignored repo-wide; added a `!release-info/schemas/**` exception so generated schemas are tracked while other release-info artifacts stay ignored.
- **Skipped from generation**: `Msg*Response` types, `Query*` types, historical `tokenization.v27/v28/v29` and `gamm.v2`/`poolmanager.v2` versioned subdirs, module-config packages.

## Linked backlog tickets

Closes BitBadges/bitbadges-autopilot#0352, #0355 (autopilot backlog). Forwarder doc lays groundwork for #0360.

🤖 Generated with [Claude Code](https://claude.com/claude-code)