### PR TITLE
chain(cli): drop auth from forwarder doc (SIWBB removed)

### DIFF
--- a/cmd/bitbadgeschaind/cmd/cli_cmd.go
+++ b/cmd/bitbadgeschaind/cmd/cli_cmd.go
@@ -41,7 +41,6 @@ Where <subcommand> is any top-level bitbadges-cli subcommand:
   builder   — template builders, create-with-burner, burner wallets,
               review/verify/simulate/doctor, session tools, builder tools
   config    — manage ~/.bitbadges/config.json (base URL, API keys per network)
-  auth      — login/logout/status (ships via the SDK CLI release for #0360)
 
 New top-level bitbadges-cli subcommands automatically reach here without
 needing a Go alias — this wrapper is the single bridge between the chain


### PR DESCRIPTION
## Summary

The chain \`cli\` forwarder doc still listed \`auth — login/logout/status\` as a top-level forwarded subcommand. That bullet was added in agent-UX push #85 anticipating the SIWBB CLI flow, but SIWBB was subsequently deprecated and the auth subcommand was removed from the SDK CLI.

This drops the dangling reference. No code path changes — the forwarder is still a generic catch-all (\`bitbadgeschaind cli <subcmd>\` → \`bitbadges-cli <subcmd>\`).

## Test plan

- [ ] \`bitbadgeschaind cli --help\` no longer mentions \`auth\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)