### PR TITLE
cmd: add sign-arbitrary ADR-36 offline signer

### DIFF
--- a/cmd/bitbadgeschaind/cmd/commands.go
+++ b/cmd/bitbadgeschaind/cmd/commands.go
@@ -86,6 +86,7 @@ func initRootCmd(
 		txCommand(),
 		bitbadgesclient.KeyCommands(app.DefaultNodeHome, false), // false = don't default to eth keys, but support them
 		CliCmd(), // canonical forwarder — `bitbadgeschaind cli <subcmd> [args...]` reaches every bitbadges-cli subcommand
+		SignArbitraryCmd(),
 	)
 }
 

--- a/cmd/bitbadgeschaind/cmd/sign_arbitrary.go
+++ b/cmd/bitbadgeschaind/cmd/sign_arbitrary.go
@@ -1,0 +1,213 @@
+package cmd
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	cryptokeyring "github.com/cosmos/cosmos-sdk/crypto/keyring"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	signingtypes "github.com/cosmos/cosmos-sdk/types/tx/signing"
+	"github.com/spf13/cobra"
+)
+
+const (
+	flagMessageFile = "message-file"
+	flagOutputMode  = "output"
+
+	algoSecp256k1 = "secp256k1"
+	formatADR36   = "adr36"
+)
+
+// SignArbitraryCmd produces an ADR-36 signature over an arbitrary
+// message using a key from the local keyring. Output is the JSON
+// envelope the bitbadges-cli `auth verify` flow expects:
+//
+//	{ format, address, pubKey, signature, message, algo }
+//
+// The signed bytes are byte-equal to Keplr's serializeSignDoc(
+// makeADR36AminoSignDoc(...)) and verify via @keplr-wallet/cosmos
+// verifyADR36Amino.
+//
+// v1 supports secp256k1 keys only; eth_secp256k1 keys are rejected
+// with a clear error pointing at a future --format eip191 flag.
+func SignArbitraryCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sign-arbitrary <key-name-or-address> [message]",
+		Short: "Sign an arbitrary message via ADR-36 (offline; for CLI auth flows)",
+		Long: `Sign an arbitrary message with a local keyring key, producing an
+ADR-36-formatted signature suitable for posting to BitBadges
+indexer's /api/v0/auth/verify endpoint.
+
+This is a pure offline operation — no network calls, no chain state,
+no transaction is broadcast. It exists to bridge the BitBadges CLI
+auth flow ('bitbadges-cli auth verify --signature ...') with keys
+held in the chain binary's keyring, without exposing the raw private
+key.
+
+Message is read from (in order): positional argument, --message-file,
+or stdin when piped. Reading from a TTY without a message source
+prints usage rather than hanging.
+
+Examples:
+  bitbadgeschaind sign-arbitrary mykey "auth challenge text"
+  echo -n "auth challenge text" | bitbadgeschaind sign-arbitrary mykey
+  bitbadgeschaind sign-arbitrary mykey --message-file challenge.txt`,
+		Args: cobra.RangeArgs(1, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			message, err := readMessage(cmd, args)
+			if err != nil {
+				return err
+			}
+
+			record, err := loadKey(clientCtx.Keyring, args[0])
+			if err != nil {
+				return fmt.Errorf("load key %q: %w", args[0], err)
+			}
+
+			pub, err := record.GetPubKey()
+			if err != nil {
+				return fmt.Errorf("get pubkey: %w", err)
+			}
+			if pub.Type() != algoSecp256k1 {
+				return fmt.Errorf(
+					"key %q has algo %q; only %q is supported in v1 "+
+						"(eth_secp256k1 / EIP-191 personal_sign support is a planned --format eip191 follow-up). "+
+						"Create a compatible key with: bitbadgeschaind keys add <name> --key-type secp256k1",
+					args[0], pub.Type(), algoSecp256k1,
+				)
+			}
+
+			addr, err := record.GetAddress()
+			if err != nil {
+				return fmt.Errorf("derive address: %w", err)
+			}
+			bech := addr.String()
+
+			signBytes, err := buildADR36SignBytes(bech, message)
+			if err != nil {
+				return fmt.Errorf("build sign-doc: %w", err)
+			}
+
+			sig, _, err := clientCtx.Keyring.SignByAddress(
+				addr,
+				signBytes,
+				signingtypes.SignMode_SIGN_MODE_LEGACY_AMINO_JSON,
+			)
+			if err != nil {
+				return fmt.Errorf("sign: %w", err)
+			}
+
+			outputMode, _ := cmd.Flags().GetString(flagOutputMode)
+			return emitOutput(cmd.OutOrStdout(), outputMode, map[string]any{
+				"format":    formatADR36,
+				"algo":      pub.Type(),
+				"address":   bech,
+				"pubKey":    base64.StdEncoding.EncodeToString(pub.Bytes()),
+				"signature": base64.StdEncoding.EncodeToString(sig),
+				"message":   message,
+			})
+		},
+	}
+
+	cmd.Flags().String(flagMessageFile, "", "Read message from file (mutually exclusive with positional message and stdin)")
+	cmd.Flags().String(flagOutputMode, "json", "Output mode: json | raw (raw prints only the base64 signature)")
+
+	flags.AddKeyringFlags(cmd.Flags())
+	cmd.Flags().String(flags.FlagHome, "", "The application home directory")
+	return cmd
+}
+
+// buildADR36SignBytes constructs the canonical ADR-36 StdSignDoc and
+// returns its serialized form (sorted keys, HTML-escaped <>&). Bytes
+// are byte-equal to Keplr's serializeSignDoc(makeADR36AminoSignDoc(...))
+// — verified by spike against @keplr-wallet/cosmos.
+func buildADR36SignBytes(signer, message string) ([]byte, error) {
+	doc := map[string]any{
+		"account_number": "0",
+		"chain_id":       "",
+		"fee":            map[string]any{"amount": []any{}, "gas": "0"},
+		"memo":           "",
+		"msgs": []any{
+			map[string]any{
+				"type": "sign/MsgSignData",
+				"value": map[string]any{
+					"signer": signer,
+					"data":   base64.StdEncoding.EncodeToString([]byte(message)),
+				},
+			},
+		},
+		"sequence": "0",
+	}
+	raw, err := json.Marshal(doc)
+	if err != nil {
+		return nil, err
+	}
+	return sdk.MustSortJSON(raw), nil
+}
+
+// loadKey accepts either a key name or a bech32 address.
+func loadKey(kr cryptokeyring.Keyring, ref string) (*cryptokeyring.Record, error) {
+	if addr, err := sdk.AccAddressFromBech32(ref); err == nil {
+		return kr.KeyByAddress(addr)
+	}
+	return kr.Key(ref)
+}
+
+// readMessage resolves the message from (in priority order) the
+// positional argument, --message-file, then stdin (only when stdin is
+// not a TTY). Multiple sources is an error.
+func readMessage(cmd *cobra.Command, args []string) (string, error) {
+	hasPositional := len(args) >= 2
+	filePath, _ := cmd.Flags().GetString(flagMessageFile)
+
+	switch {
+	case hasPositional && filePath != "":
+		return "", errors.New("specify either a positional message or --message-file, not both")
+	case hasPositional:
+		return args[1], nil
+	case filePath != "":
+		raw, err := os.ReadFile(filePath)
+		if err != nil {
+			return "", fmt.Errorf("read --message-file %s: %w", filePath, err)
+		}
+		return string(raw), nil
+	}
+
+	stat, err := os.Stdin.Stat()
+	if err != nil {
+		return "", fmt.Errorf("stat stdin: %w", err)
+	}
+	if (stat.Mode() & os.ModeCharDevice) != 0 {
+		return "", errors.New("no message provided: pass as positional arg, --message-file, or pipe via stdin")
+	}
+	raw, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return "", fmt.Errorf("read stdin: %w", err)
+	}
+	return string(raw), nil
+}
+
+func emitOutput(w io.Writer, mode string, payload map[string]any) error {
+	switch mode {
+	case "raw":
+		_, err := fmt.Fprintln(w, payload["signature"])
+		return err
+	case "", "json":
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(payload)
+	default:
+		return fmt.Errorf("unknown --output mode %q (expected json|raw)", mode)
+	}
+}

--- a/cmd/bitbadgeschaind/cmd/sign_arbitrary_test.go
+++ b/cmd/bitbadgeschaind/cmd/sign_arbitrary_test.go
@@ -1,0 +1,209 @@
+//go:build test
+// +build test
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
+	"github.com/cosmos/cosmos-sdk/crypto/hd"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	evmcryptocodec "github.com/cosmos/evm/crypto/codec"
+	evmhd "github.com/cosmos/evm/crypto/hd"
+
+	"github.com/bitbadges/bitbadgeschain/app/params"
+)
+
+func init() {
+	// SignArbitraryCmd derives bech32 addresses with the chain's
+	// configured prefix; tests must set it before any address ops.
+	params.SetAddressPrefixes()
+}
+
+// TestBuildADR36SignBytes_GoldenVector locks the canonical-JSON
+// encoding to bytes precomputed via the verification spike (Go output
+// piped into @keplr-wallet/cosmos's serializeSignDoc(makeADR36AminoSignDoc(...)),
+// confirmed byte-equal and verifyADR36Amino-PASS). Any drift in Go's
+// JSON marshaller or sdk.MustSortJSON ordering will fail this test.
+func TestBuildADR36SignBytes_GoldenVector(t *testing.T) {
+	const (
+		signer  = "bb1mnyn7x24xj6vraxeeq56dfkxa009tvhg4wlgny"
+		message = "BitBadges sign-arbitrary spike message — testing < > & escapes"
+	)
+	const expected = `{"account_number":"0","chain_id":"","fee":{"amount":[],"gas":"0"},"memo":"","msgs":[{"type":"sign/MsgSignData","value":{"data":"Qml0QmFkZ2VzIHNpZ24tYXJiaXRyYXJ5IHNwaWtlIG1lc3NhZ2Ug4oCUIHRlc3RpbmcgPCA+ICYgZXNjYXBlcw==","signer":"bb1mnyn7x24xj6vraxeeq56dfkxa009tvhg4wlgny"}}],"sequence":"0"}`
+
+	got, err := buildADR36SignBytes(signer, message)
+	if err != nil {
+		t.Fatalf("buildADR36SignBytes: %v", err)
+	}
+	if string(got) != expected {
+		t.Fatalf("sign bytes drifted from spike-verified golden vector\nwant: %s\ngot : %s", expected, string(got))
+	}
+}
+
+// TestSignArbitrary_RoundTrip_Secp256k1 exercises the full command
+// against an in-memory keyring with a true cosmos secp256k1 key, then
+// verifies the produced signature locally via PubKey.VerifySignature.
+func TestSignArbitrary_RoundTrip_Secp256k1(t *testing.T) {
+	kr, addr, pub := newInMemoryKeyring(t, "tester", hd.Secp256k1)
+
+	out := executeSignArbitrary(t, kr, []string{"tester", "hello world"}, "")
+
+	var got struct {
+		Format    string `json:"format"`
+		Algo      string `json:"algo"`
+		Address   string `json:"address"`
+		Signature string `json:"signature"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("parse output: %v\noutput: %s", err, out)
+	}
+	if got.Format != "adr36" || got.Algo != "secp256k1" {
+		t.Fatalf("wrong format/algo: %+v", got)
+	}
+	if got.Address != addr.String() {
+		t.Fatalf("wrong address: want %s got %s", addr.String(), got.Address)
+	}
+
+	signBytes, err := buildADR36SignBytes(addr.String(), "hello world")
+	if err != nil {
+		t.Fatalf("rebuild signBytes: %v", err)
+	}
+	sig, err := base64.StdEncoding.DecodeString(got.Signature)
+	if err != nil {
+		t.Fatalf("decode sig: %v", err)
+	}
+	if !pub.VerifySignature(signBytes, sig) {
+		t.Fatalf("VerifySignature returned false — signing path produced an invalid signature")
+	}
+}
+
+// TestSignArbitrary_RejectsEthSecp256k1 confirms v1 refuses
+// eth_secp256k1 keys with a clear actionable error rather than
+// silently producing a signature CosmosDriver will reject.
+func TestSignArbitrary_RejectsEthSecp256k1(t *testing.T) {
+	kr, _, _ := newInMemoryKeyring(t, "ethkey", evmhd.EthSecp256k1)
+
+	cmd := SignArbitraryCmd()
+	out := &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"ethkey", "hello"})
+
+	cmd.SetContext(context.Background())
+	clientCtx := client.Context{}.WithKeyring(kr)
+	if err := client.SetCmdClientContext(cmd, clientCtx); err != nil {
+		t.Fatalf("set cmd ctx: %v", err)
+	}
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error rejecting eth_secp256k1, got success: %s", out.String())
+	}
+	if !strings.Contains(err.Error(), "eth_secp256k1") || !strings.Contains(err.Error(), "secp256k1") {
+		t.Fatalf("error should mention both algos for clarity, got: %v", err)
+	}
+}
+
+func TestReadMessage_Modes(t *testing.T) {
+	t.Run("positional and file are mutually exclusive", func(t *testing.T) {
+		cmd := SignArbitraryCmd()
+		_ = cmd.Flags().Set(flagMessageFile, "/tmp/whatever")
+		_, err := readMessage(cmd, []string{"keyname", "inline-msg"})
+		if err == nil || !strings.Contains(err.Error(), "not both") {
+			t.Fatalf("expected mutual-exclusion error, got: %v", err)
+		}
+	})
+	t.Run("positional wins when alone", func(t *testing.T) {
+		cmd := SignArbitraryCmd()
+		got, err := readMessage(cmd, []string{"keyname", "the-message"})
+		if err != nil || got != "the-message" {
+			t.Fatalf("want the-message, got %q err %v", got, err)
+		}
+	})
+	t.Run("file is read when provided", func(t *testing.T) {
+		path := writeTempFile(t, "from-the-file")
+		cmd := SignArbitraryCmd()
+		_ = cmd.Flags().Set(flagMessageFile, path)
+		got, err := readMessage(cmd, []string{"keyname"})
+		if err != nil || got != "from-the-file" {
+			t.Fatalf("want from-the-file, got %q err %v", got, err)
+		}
+	})
+}
+
+// ── helpers ─────────────────────────────────────────────────────────
+
+func newInMemoryKeyring(t *testing.T, name string, algo keyring.SignatureAlgo) (keyring.Keyring, sdk.AccAddress, cryptotypes.PubKey) {
+	t.Helper()
+	registry := codectypes.NewInterfaceRegistry()
+	cryptocodec.RegisterInterfaces(registry)
+	evmcryptocodec.RegisterInterfaces(registry)
+	cdc := codec.NewProtoCodec(registry)
+	kr := keyring.NewInMemory(cdc, evmhd.EthSecp256k1Option())
+
+	rec, _, err := kr.NewMnemonic(
+		name,
+		keyring.English,
+		sdk.GetConfig().GetFullBIP44Path(),
+		"",
+		algo,
+	)
+	if err != nil {
+		t.Fatalf("NewMnemonic: %v", err)
+	}
+	addr, err := rec.GetAddress()
+	if err != nil {
+		t.Fatalf("GetAddress: %v", err)
+	}
+	pub, err := rec.GetPubKey()
+	if err != nil {
+		t.Fatalf("GetPubKey: %v", err)
+	}
+	return kr, addr, pub
+}
+
+// executeSignArbitrary runs the command end-to-end against the given
+// keyring and returns stdout (the JSON envelope).
+func executeSignArbitrary(t *testing.T, kr keyring.Keyring, args []string, output string) string {
+	t.Helper()
+	cmd := SignArbitraryCmd()
+	out := &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs(args)
+	if output != "" {
+		_ = cmd.Flags().Set(flagOutputMode, output)
+	}
+	cmd.SetContext(context.Background())
+	clientCtx := client.Context{}.WithKeyring(kr)
+	if err := client.SetCmdClientContext(cmd, clientCtx); err != nil {
+		t.Fatalf("set cmd ctx: %v", err)
+	}
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v\noutput: %s", err, out.String())
+	}
+	return out.String()
+}
+
+func writeTempFile(t *testing.T, contents string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "msg.txt")
+	if err := os.WriteFile(p, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write tmp file: %v", err)
+	}
+	return p
+}


### PR DESCRIPTION
## Summary

- Adds `bitbadgeschaind sign-arbitrary <key> [message]` — a pure-offline subcommand that produces an ADR-36 signature over an arbitrary message using a key from the local keyring, without ever exposing the raw private key.
- Output JSON envelope `{ format, address, pubKey, signature, message, algo }` posts directly to the indexer's `/api/v0/auth/verify` endpoint.
- Bridges the new wallet-agnostic `bitbadges-cli auth` flow (BitBadges/bitbadgesjs#TBD) to chain-binary keyring keys for headless / agentic use.

## Why this exists

Cosmos-sdk's CLI exposes signing only through `tx sign`, which builds a StdTx envelope around registered `sdk.Msg` types — not arbitrary bytes. ADR-36 needs raw canonical-JSON bytes signed directly. The keyring primitive (`keystore.Sign(uid, msg, signMode)`) is right there in cosmos-sdk; this just plumbs it to a CLI surface.

The only previous escape hatches were `keys unsafe-export-eth-key` / `keys export --unarmored-hex` — privkey hex hits process memory + shell history. Hard no for an agent that auths repeatedly.

## Scope

**v1 supports `secp256k1` keys only** — the indexer's `CosmosDriver.verifySignature` accepts these unchanged via `@keplr-wallet/cosmos verifyADR36Amino`. `eth_secp256k1` keys are rejected with a clear error pointing at a future `--format eip191` follow-up.

No msg-type registration. No edits to `tx sign`. No proto codegen.

## Files

- NEW `cmd/bitbadgeschaind/cmd/sign_arbitrary.go` — command + helpers
- NEW `cmd/bitbadgeschaind/cmd/sign_arbitrary_test.go` (`//go:build test`) — golden vector + round-trip + reject-eth-key + message-source tests
- EDIT `cmd/bitbadgeschaind/cmd/commands.go` — single `SignArbitraryCmd(),` line in `initRootCmd`

## Verification

- Pre-impl spike: Go's `sdk.MustSortJSON(json.Marshal(map))` produces bytes byte-equal to Keplr's `serializeSignDoc(makeADR36AminoSignDoc(...))`. Verified by piping Go output into `verifyADR36Amino` against the indexer's pinned `@keplr-wallet/cosmos`. PASS.
- Golden-vector unit test locks the canonical-JSON encoding against the spike-verified bytes — any drift in Go's JSON marshaller will fail loudly.
- E2E against mainnet `https://api.bitbadges.io/api/v0/auth/*`: fresh local key signs Blockin challenge → indexer mints Full Access session cookie → `auth status` confirms server-side signed-in.

## Test plan

- [ ] `go test -tags=test ./cmd/bitbadgeschaind/cmd/` — golden vector, round-trip, eth_secp256k1 rejection, message-source modes
- [ ] `bitbadgeschaind sign-arbitrary --help` lists the command
- [ ] `bitbadgeschaind sign-arbitrary <key> "hello"` returns valid JSON
- [ ] Output verifies via `@keplr-wallet/cosmos verifyADR36Amino` (manual: pipe through Node)

🤖 Generated with [Claude Code](https://claude.com/claude-code)