### PR TITLE
test: fix TestGenesis_ValidTokenIdsPreserved + TestGetKnownGoodCollectionId

### DIFF
--- a/x/tokenization/ai_test/unit/genesis/genesis_test.go
+++ b/x/tokenization/ai_test/unit/genesis/genesis_test.go
@@ -348,9 +348,10 @@ func (suite *GenesisTestSuite) TestGenesis_ValidTokenIdsPreserved() {
 		DefaultBalances: &types.UserBalanceStore{
 			Balances: []*types.Balance{},
 		},
+		// Token IDs must be sequential starting from 1 (see keeper.CreateTokens).
+		// A single contiguous range satisfies that; multi-range with a gap does not.
 		ValidTokenIds: []*types.UintRange{
-			{Start: sdkmath.NewUint(1), End: sdkmath.NewUint(50)},
-			{Start: sdkmath.NewUint(100), End: sdkmath.NewUint(200)},
+			{Start: sdkmath.NewUint(1), End: sdkmath.NewUint(200)},
 		},
 		CollectionPermissions: &types.CollectionPermissions{},
 		Manager:               suite.Manager,

--- a/x/tokenization/simulation/helpers.go
+++ b/x/tokenization/simulation/helpers.go
@@ -498,8 +498,13 @@ func GetOrCreateCollection(ctx sdk.Context, k *keeper.Keeper, creator string, r 
 		return collectionId, nil
 	}
 
-	// Create a minimal valid collection
-	validTokenIds := GetBoundedTimelineTimes(r, 1, MinTimelineRange, MaxTimelineRange)
+	// Create a minimal valid collection.
+	// Token IDs must be sequential starting from 1 (see keeper.CreateTokens).
+	// `GetBoundedTimelineTimes` produces randomly-positioned ranges, which
+	// is correct for timeline-time fields but invalid for ValidTokenIds.
+	validTokenIds := []*types.UintRange{
+		{Start: sdkmath.NewUint(1), End: sdkmath.NewUint(uint64(1 + r.Intn(1000)))},
+	}
 	collectionPermissions := GetRandomCollectionPermissions(r, accs)
 
 	collectionMetadata := &types.CollectionMetadata{


### PR DESCRIPTION
## Summary

Cherry-picks the test fix from #91 so the test suite goes green independent of the EIP-712 work (which is gated on the upstream go-ethereum patch).

Both tests authored token-id shapes the chain has never accepted. `keeper.CreateTokens` (`tokens.go:23`) requires `ValidTokenIds` to be a single contiguous range starting from 1 — a constraint dating back to the v0.47 fork in 2023. These tests came in later (badges→tokenization rename and the AI-generated genesis test sweep) without ever being run against the production code path. PR #79 closed the production-side hole that had been silently dropping these invalid inputs, which unmasked them.

- `simulation/helpers.go GetOrCreateCollection`: was building `ValidTokenIds` with `GetBoundedTimelineTimes`, which returns randomly-positioned ranges appropriate for timeline-time fields (`TransferTimes`, `OwnershipTimes`) but not for token IDs. Replaced with `[{Start:1, End:1+rand}]`.
- `ai_test` genesis: was hardcoding two ranges with a gap (`[1..50]`, `[100..200]`). Replaced with single `[1..200]` range.

Refs `bitbadges-autopilot#0381`. Carved out of #91 so the test suite can be green without waiting on the EIP-712 fork merge.

## Test plan

- [x] `go test -tags=test ./x/tokenization/ai_test/unit/genesis/... -run TestGenesisTestSuite/TestGenesis_ValidTokenIdsPreserved` — passes
- [x] `go test -tags=test ./x/tokenization/simulation/... -run TestGetKnownGoodCollectionId` — passes
- [ ] Full `make test` clean in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)