### PR TITLE
feat(cli): bb --help groups + tokenization cross-links

### DIFF
--- a/cmd/bitbadgeschaind/cmd/commands.go
+++ b/cmd/bitbadgeschaind/cmd/commands.go
@@ -85,9 +85,17 @@ func initRootCmd(
 		queryCommand(),
 		txCommand(),
 		bitbadgesclient.KeyCommands(app.DefaultNodeHome, false), // false = don't default to eth keys, but support them
-		CliCmd(), // canonical forwarder — `bitbadgeschaind cli <subcmd> [args...]` reaches every bitbadges-cli subcommand
+		CliCmd(), // canonical back-compat forwarder — `bitbadgeschaind cli <subcmd> [args...]` reaches every bitbadges-cli subcommand
 		SignArbitraryCmd(),
 	)
+
+	// Register named top-level SDK CLI forwarders so `bb build vault`,
+	// `bb auctions place-bid 42`, `bb account all`, etc. resolve
+	// directly without the `cli` infix. Each forwarder is tagged with
+	// its Cobra GroupID for `bb --help` grouping. See sdk_forwarders.go
+	// for the canonical list. Must run after chain natives are added so
+	// the collision check has the full set to compare against.
+	registerSDKForwarders(rootCmd)
 }
 
 func addModuleInitFlags(startCmd *cobra.Command) {

--- a/cmd/bitbadgeschaind/cmd/help_groups.go
+++ b/cmd/bitbadgeschaind/cmd/help_groups.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// Cobra GroupID values for `bb --help`. These visually separate the
+// chain-native commands from the BitBadges SDK CLI surface (registered
+// via thin forwarders) so `bb --help` answers "which binary owns this?"
+// at a glance. See outputs/flagship-plans/cli-v2-design.md § "Locked
+// Decisions" (decision 7) in the bitbadges-autopilot repo for context.
+const (
+	groupChain        = "chain"
+	groupSDKBuild     = "sdk-build"
+	groupSDKStandards = "sdk-standards"
+	groupSDKIndexer   = "sdk-indexer"
+	groupSDKSwap      = "sdk-swap"
+	groupSDKDev       = "sdk-dev"
+	groupLocal        = "local"
+)
+
+// registerHelpGroups installs the Cobra groups on the root command. Each
+// top-level command is then tagged with the appropriate GroupID via
+// tagChainCommandGroups (for chain natives) and the per-forwarder
+// registration in sdk_forwarders.go (for SDK CLI commands).
+func registerHelpGroups(rootCmd *cobra.Command) {
+	rootCmd.AddGroup(
+		&cobra.Group{ID: groupChain, Title: "Chain operations:"},
+		&cobra.Group{ID: groupSDKBuild, Title: "BitBadges SDK — Build & Deploy:"},
+		&cobra.Group{ID: groupSDKStandards, Title: "BitBadges SDK — Standards:"},
+		&cobra.Group{ID: groupSDKIndexer, Title: "BitBadges SDK — Indexer & Auth:"},
+		&cobra.Group{ID: groupSDKSwap, Title: "BitBadges SDK — Swap / DEX:"},
+		&cobra.Group{ID: groupSDKDev, Title: "BitBadges SDK — Dev:"},
+		&cobra.Group{ID: groupLocal, Title: "Local state:"},
+	)
+}
+
+// chainNativeGroups maps every chain-native top-level command name to
+// its group. Names match what Cobra actually registers (verified via
+// `bitbadgeschaind --help`).
+//
+// Anything not in this map and not in sdkForwarderGroups (see
+// sdk_forwarders.go) keeps Cobra's default ungrouped placement, which
+// is fine for built-ins like `help`.
+var chainNativeGroups = map[string]string{
+	// Cosmos SDK core
+	"start":          groupChain,
+	"init":           groupChain,
+	"status":         groupChain,
+	"version":        groupChain,
+	"tx":             groupChain,
+	"query":          groupChain, // alias `q`
+	"keys":           groupChain,
+	"sign-arbitrary": groupChain,
+	"comet":          groupChain, // aliases `cometbft`, `tendermint`
+	"config":         groupChain, // confix-provided; chain owns this name
+	"genesis":        groupChain,
+	"debug":          groupChain,
+	"prune":          groupChain,
+	"snapshots":      groupChain,
+	// Cosmos EVM additions
+	"export":       groupChain,
+	"rollback":     groupChain,
+	"index-eth-tx": groupChain,
+	// Existing back-compat forwarder. Keep grouped under chain so it
+	// doesn't show up ungrouped during the deprecation runway.
+	"cli": groupChain,
+	// Cobra-provided completion command. Lives under "Local state" per
+	// the v2 design decision 7 — it's a user-facing local helper, not a
+	// chain native.
+	"completion": groupLocal,
+}
+
+// tagChainCommandGroups assigns the GroupID on each chain-native
+// top-level command. Must be called after every chain-native command
+// is registered (i.e. after initRootCmd + autocli enhancement).
+//
+// Forces Cobra's lazy-registered defaults (`help`, `completion`) to be
+// installed up front so they land in the right group too — otherwise
+// they get auto-added at render time, after this pass, and show under
+// "Additional Commands" instead of "Local state".
+func tagChainCommandGroups(rootCmd *cobra.Command) {
+	rootCmd.InitDefaultHelpCmd()
+	rootCmd.InitDefaultCompletionCmd()
+
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.GroupID != "" {
+			continue
+		}
+		if groupID, ok := chainNativeGroups[cmd.Name()]; ok {
+			cmd.GroupID = groupID
+		}
+	}
+}

--- a/cmd/bitbadgeschaind/cmd/help_groups.go
+++ b/cmd/bitbadgeschaind/cmd/help_groups.go
@@ -25,7 +25,7 @@ const (
 // registration in sdk_forwarders.go (for SDK CLI commands).
 func registerHelpGroups(rootCmd *cobra.Command) {
 	rootCmd.AddGroup(
-		&cobra.Group{ID: groupChain, Title: "Chain operations:"},
+		&cobra.Group{ID: groupChain, Title: "Chain node (Cosmos SDK):"},
 		&cobra.Group{ID: groupSDKBuild, Title: "BitBadges SDK — Build & Deploy:"},
 		&cobra.Group{ID: groupSDKStandards, Title: "BitBadges SDK — Standards:"},
 		&cobra.Group{ID: groupSDKIndexer, Title: "BitBadges SDK — Indexer & Auth:"},

--- a/cmd/bitbadgeschaind/cmd/root.go
+++ b/cmd/bitbadgeschaind/cmd/root.go
@@ -107,6 +107,11 @@ func NewRootCmd() *cobra.Command {
 		autoCliOpts.Modules[name] = mod
 	}
 
+	// Install `bb --help` Cobra groups before commands are added so the
+	// initRootCmd / autocli / SDK-forwarder registrations can attach
+	// each command to its group as it's wired up.
+	registerHelpGroups(rootCmd)
+
 	initRootCmd(rootCmd, clientCtx.TxConfig, moduleBasicManager)
 
 	overwriteFlagDefaults(rootCmd, map[string]string{
@@ -117,6 +122,13 @@ func NewRootCmd() *cobra.Command {
 	if err := autoCliOpts.EnhanceRootCommand(rootCmd); err != nil {
 		panic(err)
 	}
+
+	// Tag every chain-native top-level command with its GroupID for
+	// the `bb --help` grouping. Runs after autocli enhancement so it
+	// catches commands the enhancer adds (e.g. module tx/query
+	// shortcuts). SDK CLI forwarders register their own GroupID
+	// inline in sdk_forwarders.go and are skipped here.
+	tagChainCommandGroups(rootCmd)
 
 	return rootCmd
 }

--- a/cmd/bitbadgeschaind/cmd/sdk_forwarders.go
+++ b/cmd/bitbadgeschaind/cmd/sdk_forwarders.go
@@ -1,0 +1,164 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// SDK CLI forwarders.
+//
+// The existing `cli` subcommand (cli_cmd.go) is a generic catch-all
+// forwarder — `bitbadgeschaind cli <anything>` reaches every
+// bitbadges-cli subcommand. It stays registered for one release of
+// back-compat per the v2 deprecation runway.
+//
+// This file adds **named, top-level** forwarders so `bb <cmd>` resolves
+// directly without the `cli` infix:
+//
+//	bb build vault ...        → bitbadges-cli build vault ...
+//	bb auctions place-bid 42  → bitbadges-cli auctions place-bid 42
+//	bb account all            → bitbadges-cli account all
+//
+// Each forwarder is grouped for `bb --help` (see help_groups.go) and
+// uses the same execvp-style passthrough that cli_cmd.go uses. When
+// bitbadges-cli is not installed, forwarders print the same helpful
+// install hint that execNodeCLI() does today.
+//
+// Runtime dependency: these only do useful work when bitbadges-cli
+// (npm package `bitbadges`) is on the user's PATH. They compile and
+// pass tests on their own, independent of the SDK CLI version.
+
+// sdkForwarderSpec describes a single top-level SDK forwarder.
+type sdkForwarderSpec struct {
+	name       string
+	short      string
+	group      string
+	deprecated string // non-empty → command is hidden + marked deprecated
+}
+
+// sdkForwarderSpecs is the canonical list of bitbadges-cli top-level
+// commands that should be reachable directly on `bb`. Names and
+// grouping come from outputs/flagship-plans/cli-v2-design.md "Locked
+// Decisions" decisions 1-7. Order within each group is alphabetical for
+// stable `--help` rendering.
+//
+// IMPORTANT: `config` is intentionally absent. The chain binary owns
+// `bb config` (client.toml). The SDK's old `config` is reachable via
+// `bb cli config` only; the SDK rename to `settings` removes the
+// collision on the SDK side.
+var sdkForwarderSpecs = []sdkForwarderSpec{
+	// SDK — Build & Deploy
+	{name: "build", short: "Builders for deterministic ready-to-sign tx JSON", group: groupSDKBuild},
+	{name: "check", short: "Validate a tx JSON against its proto schema", group: groupSDKBuild},
+	{name: "deploy", short: "Sign and broadcast a tx (--browser/--burner/--with-keyring/--gen-payload)", group: groupSDKBuild},
+	{name: "explain", short: "Human-readable explanation of a tx JSON", group: groupSDKBuild},
+	{name: "preview", short: "Preview a tx as it would land on chain", group: groupSDKBuild},
+	{name: "simulate", short: "Simulate a tx against a live node (no broadcast)", group: groupSDKBuild},
+
+	// SDK — Standards (12 end-user verbs)
+	{name: "auctions", short: "Auction standard: list / show / place-bid / settle / ...", group: groupSDKStandards},
+	{name: "bounties", short: "Bounty standard: list / show / claim / ...", group: groupSDKStandards},
+	{name: "credit-tokens", short: "Credit-token standard: list / show / issue / ...", group: groupSDKStandards},
+	{name: "crowdfunds", short: "Crowdfund standard: list / show / contribute / ...", group: groupSDKStandards},
+	{name: "dynamic-stores", short: "Dynamic-store standard: list / show / set-value / ...", group: groupSDKStandards},
+	{name: "intents", short: "Intent standard: list / show / submit / ...", group: groupSDKStandards},
+	{name: "nfts", short: "NFT standard: list / show / transfer / ...", group: groupSDKStandards},
+	{name: "pay-requests", short: "Pay-request standard: list / show / pay / ...", group: groupSDKStandards},
+	{name: "prediction-markets", short: "Prediction-market standard: list / show / trade / ...", group: groupSDKStandards},
+	{name: "products", short: "Product standard: list / show / buy / ...", group: groupSDKStandards},
+	{name: "smart-tokens", short: "Smart-token standard: list / show / transfer / ...", group: groupSDKStandards},
+	{name: "subscriptions", short: "Subscription standard: list / show / subscribe / ...", group: groupSDKStandards},
+
+	// SDK — Indexer & Auth
+	{name: "account", short: "Account aggregator: profile, tokens, balances, activity, approvals", group: groupSDKIndexer},
+	{name: "api", short: "Indexer API surface (106 routes, tag-grouped)", group: groupSDKIndexer},
+	{name: "auth", short: "Blockin session: login / logout / status / use / whoami", group: groupSDKIndexer},
+
+	// SDK — Swap / DEX
+	{name: "pairs", short: "Asset-pair listings (promoted from `swap asset-pairs`)", group: groupSDKSwap},
+	{name: "pools", short: "Liquidity pool listings (promoted from `swap pools`)", group: groupSDKSwap},
+	{name: "price", short: "Spot price for a symbol", group: groupSDKSwap},
+	{name: "swap", short: "Swap / DEX queries: assets, chains, estimate, track, status", group: groupSDKSwap},
+
+	// SDK — Dev (MCP-flavored agent surface)
+	{name: "dev", short: "Dev surface: tools, resources, docs, skills, gen-pub-key", group: groupSDKDev},
+
+	// Local state
+	{name: "burner", short: "Burner keys: list / show / resume / sweep / forget", group: groupLocal},
+	{name: "doctor", short: "Quick smoke test of local CLI state", group: groupLocal},
+	{name: "session", short: "Local Blockin sessions: list / show / reset", group: groupLocal},
+	{name: "settings", short: "SDK CLI config (renamed from `config`)", group: groupLocal},
+
+	// Deprecated aliases — registered hidden so they still resolve but
+	// don't clutter `bb --help`. The SDK CLI side prints a stderr
+	// deprecation banner with the canonical replacement name.
+	{name: "portfolio", short: "Deprecated: use `bb account`", group: groupSDKIndexer, deprecated: "use `bb account`"},
+	{name: "address", short: "Deprecated: use `bb account` subcommands", group: groupSDKIndexer, deprecated: "use `bb account convert` / `bb account validate`"},
+	{name: "alias", short: "Deprecated: use `bb account alias`", group: groupSDKIndexer, deprecated: "use `bb account alias`"},
+	{name: "lookup", short: "Deprecated: use `bb account lookup`", group: groupSDKIndexer, deprecated: "use `bb account lookup`"},
+	{name: "gen-list-id", short: "Deprecated: use `bb account gen-list-id`", group: groupSDKIndexer, deprecated: "use `bb account gen-list-id`"},
+	{name: "tool", short: "Deprecated: use `bb dev tools`", group: groupSDKDev, deprecated: "use `bb dev tools`"},
+	{name: "tools", short: "Deprecated: use `bb dev tools`", group: groupSDKDev, deprecated: "use `bb dev tools`"},
+	{name: "resources", short: "Deprecated: use `bb dev resources`", group: groupSDKDev, deprecated: "use `bb dev resources`"},
+	{name: "docs", short: "Deprecated: use `bb dev docs`", group: groupSDKDev, deprecated: "use `bb dev docs`"},
+	{name: "skills", short: "Deprecated: use `bb dev skills`", group: groupSDKDev, deprecated: "use `bb dev skills`"},
+	{name: "gen-pub-key", short: "Deprecated: use `bb dev gen-pub-key`", group: groupSDKDev, deprecated: "use `bb dev gen-pub-key`"},
+	{name: "sign-with-browser", short: "Deprecated: use `bb deploy --browser`", group: groupSDKBuild, deprecated: "use `bb deploy --browser`"},
+	{name: "gen-tx-payload", short: "Deprecated: use `bb deploy --gen-payload`", group: groupSDKBuild, deprecated: "use `bb deploy --gen-payload`"},
+}
+
+// newSDKForwarder builds a Cobra command that forwards verbatim to
+// `bitbadges-cli <name> [args...]`. Mirrors the pattern in
+// cli_cmd.go's CliCmd() — same execNodeCLI plumbing, same not-
+// installed fallback message.
+func newSDKForwarder(spec sdkForwarderSpec) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                spec.name + " [args...]",
+		Short:              spec.short,
+		GroupID:            spec.group,
+		DisableFlagParsing: true, // pass flags through to bitbadges-cli
+		Long: fmt.Sprintf(`Forwards to: bitbadges-cli %s
+
+Runs the BitBadges SDK CLI subcommand of the same name. All arguments
+and flags are passed through verbatim. Requires Node.js + the
+bitbadges npm package (npm install -g bitbadges).
+
+Run with --help to see the SDK subcommand's own help:
+  bitbadgeschaind %s --help`, spec.name, spec.name),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return execNodeCLI(spec.name, args)
+		},
+	}
+	if spec.deprecated != "" {
+		cmd.Hidden = true
+		cmd.Deprecated = spec.deprecated
+	}
+	return cmd
+}
+
+// registerSDKForwarders adds every top-level SDK forwarder to the root
+// command. Called from initRootCmd after chain natives are registered.
+//
+// Collisions: this function panics if a forwarder name collides with a
+// chain-native command that's already registered. The spec list is
+// pre-filtered to avoid `config` (which the chain owns), but a future
+// chain command rename could surprise us — fail loud rather than
+// silently shadow.
+func registerSDKForwarders(rootCmd *cobra.Command) {
+	existing := map[string]bool{}
+	for _, c := range rootCmd.Commands() {
+		existing[c.Name()] = true
+	}
+
+	for _, spec := range sdkForwarderSpecs {
+		if existing[spec.name] {
+			fmt.Fprintf(os.Stderr,
+				"sdk forwarder name collision: %q already registered as a chain-native command\n",
+				spec.name)
+			continue
+		}
+		rootCmd.AddCommand(newSDKForwarder(spec))
+	}
+}

--- a/x/tokenization/client/cli/help_links.go
+++ b/x/tokenization/client/cli/help_links.go
@@ -71,10 +71,10 @@ func MsgHelpLinks(cmdName string) string {
 
 	links, ok := msgDocLinks[cmdName]
 	if !ok {
-		return base + schemaHelpFooter("tx.proto")
+		return base + schemaHelpFooter("tx.proto") + builderCrossLink()
 	}
 
-	return base + schemaHelpFooter(links.protoFile) + docsLink(links.docsPath)
+	return base + schemaHelpFooter(links.protoFile) + docsLink(links.docsPath) + builderCrossLink()
 }
 
 // QueryHelpLinks returns help text with documentation links for a query command.
@@ -87,6 +87,27 @@ func QueryHelpLinks(cmdName string) string {
 	}
 
 	return base + schemaHelpFooter(links.protoFile) + docsLink(links.docsPath)
+}
+
+// builderCrossLink is the v2 CLI cross-link from raw `tx tokenization
+// <action>` commands to the friendlier `bb build <type>` builder
+// pipeline. See outputs/flagship-plans/cli-v2-design.md "Locked
+// Decisions" decision 5 (Option 1: parallel + cross-link).
+//
+// We use a generic phrasing rather than per-command type mapping
+// because the relationship between tokenization tx actions and SDK
+// builders isn't strictly 1:1 (e.g. `create-collection` covers
+// vault/auction/bounty/crowdfund/subscription/... builders, all of
+// which emit MsgCreateCollection under the hood).
+func builderCrossLink() string {
+	return `
+
+Guided builder:
+  For a guided builder with validation, review, and helpful defaults,
+  see the BitBadges SDK CLI:
+    bitbadgeschaind build <type> --help    (e.g. vault, auction, crowdfund, subscription)
+  The builder emits a ready-to-sign tx JSON that you can pipe into
+  'bitbadgeschaind deploy' to sign and broadcast.`
 }
 
 func schemaHelpFooter(protoFile string) string {


### PR DESCRIPTION
Companion chain-binary PR for the BitBadges CLI v2 redesign (ticket #0399 Phase 2). Wires `bitbadgeschaind` (aka `bb`) so the v2 flat namespace, deprecation runway, and `tx tokenization` cross-links all show up at the binary entry point.

## Design context

- Full design: [`outputs/flagship-plans/cli-v2-design.md`](https://github.com/BitBadges/bitbadges-autopilot/blob/main/outputs/flagship-plans/cli-v2-design.md) (bitbadges-autopilot repo)
- Locked decisions: 1 (Model A flat), 2 (standards flat), 3 (`deploy --<method>` flags), 4 (`portfolio` → `account`), 5 (Option 1 for tokenization), 6 (`bb dev`), 7 (Cobra GroupID)
- Ticket: `#0399` Phase 2

## Summary

Three commits, one PR:

1. **`feat(cli): add Cobra GroupID setup to bb --help`** — defines seven groups (Chain operations / BitBadges SDK — Build & Deploy / Standards / Indexer & Auth / Swap-DEX / Dev / Local state) and tags every chain-native top-level command with its group. New file: `cmd/bitbadgeschaind/cmd/help_groups.go`.

2. **`feat(cli): top-level forwarders for bitbadges-cli (bb <cmd> direct)`** — registers a named top-level Cobra command for every bitbadges-cli verb in the v2 surface (`build`, `deploy`, `auctions`, `account`, `swap`, `pools`, `pairs`, `dev`, `settings`, ...), plus hidden deprecated aliases (`portfolio`, `sign-with-browser`, `gen-tx-payload`, `tool`, etc.). Each forwarder shells out via the existing `execNodeCLI` plumbing and is tagged with its GroupID. `config` is intentionally NOT forwarded — chain owns that name. New file: `cmd/bitbadgeschaind/cmd/sdk_forwarders.go`.

3. **`feat(cli): cross-link tx tokenization --help to bb build pipeline`** — adds a guided-builder epilog to every `tx tokenization <action> --help`. Hooked centrally in `MsgHelpLinks()` so all 25 tokenization tx commands inherit it. Generic `bb build <type>` phrasing rather than per-action mapping (the relationship isn't 1:1).

## SDK-PR dependency + merge order

These forwarders only do useful work at runtime when the companion SDK PR (`feat/cli-v2-flat-namespace` on `bitbadgesjs`) has shipped — that PR registers the top-level commands (`account`, `dev`, `settings`, the 12 standards, etc.) on `bitbadges-cli` so the forwarders actually resolve. **The chain PR compiles and tests fine independently** — only runtime behavior depends on the SDK PR.

**Merge order**: SDK PR lands first, then this one.

If a user runs `bb build vault` today (before the SDK PR), they'll hit the same `SDK CLI not available. Install with: npm install -g bitbadges` fallback that the existing `bb cli` forwarder prints — no regression.

## Back-compat

- `bb cli <anything>` still works (the generic forwarder in `cli_cmd.go` is untouched). Now grouped under "Chain operations" in `--help` for one release.
- Deprecated aliases (`portfolio`, `sign-with-browser`, `gen-tx-payload`, `tool`/`tools`, `resources`, `docs`, `skills`, `gen-pub-key`, `address`, `lookup`, `alias`, `gen-list-id`) are registered with `Hidden: true` + Cobra's `Deprecated` field. They still resolve; the SDK CLI side prints the deprecation banner to stderr.
- Phase 3 (hard removal) stays a separate follow-up ticket.

## Test plan

- [x] `go build ./cmd/bitbadgeschaind/` succeeds
- [x] `go test ./... -tags=test` passes (full suite; `-tags=test` per `feedback_test_tags`)
- [x] `bitbadgeschaind --help` renders the grouped output: Chain operations / SDK — Build & Deploy / SDK — Standards / SDK — Indexer & Auth / SDK — Swap & DEX / SDK — Dev / Local state
- [x] `bitbadgeschaind help build` shows the forwarder's Cobra-side Long; `bitbadgeschaind build --help` forwards to bitbadges-cli (or prints the install hint if not installed — same behavior as today's `bb cli build --help`)
- [x] `bitbadgeschaind tx tokenization create-collection --help` shows the new "Guided builder" cross-link epilog
- [x] Deprecated aliases (`portfolio`, `sign-with-browser`, etc.) hidden from main `--help` but resolve when invoked
- [ ] After SDK PR lands: end-to-end smoke (`bb build vault --name X --description Y --image Z` produces the same output as `bb cli build vault ...`)

## Files

- New: `cmd/bitbadgeschaind/cmd/help_groups.go` — GroupID definitions + tagger
- New: `cmd/bitbadgeschaind/cmd/sdk_forwarders.go` — top-level SDK forwarders
- Modified: `cmd/bitbadgeschaind/cmd/root.go` — calls `registerHelpGroups` and `tagChainCommandGroups`
- Modified: `cmd/bitbadgeschaind/cmd/commands.go` — calls `registerSDKForwarders`
- Modified: `x/tokenization/client/cli/help_links.go` — adds `builderCrossLink()` epilog