### PR TITLE
fix(install): resolve latest release via redirect to avoid API rate limit

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -83,12 +83,48 @@ detect_arch() {
   esac
 }
 
-# Get latest release tag from GitHub API
+# Get latest release tag.
+#
+# PRIMARY: resolve via the github.com web redirect. /releases/latest 302s to
+# /releases/tag/<tag>; we read the tag off the final URL. This path does NOT
+# touch api.github.com, so it is immune to the 60/hr unauthenticated API rate
+# limit that returns HTTP 403 on shared/NAT'd IPs (corp networks, CI, boxes
+# already running `gh`).
+#
+# FALLBACK: only if the redirect yields no tag, query the API as before. Send
+# `Authorization: Bearer $GITHUB_TOKEN` when that env var is set (lifts the
+# limit to 5,000/hr).
+#
+# Note: each network call is piped into sed, whose exit 0 masks any upstream
+# `-f` failure, so `set -e` does not abort before the fallback can run.
 get_latest_version() {
+  tag=""
+
+  # PRIMARY: follow the releases/latest redirect (no API rate limit).
   if command -v curl >/dev/null 2>&1; then
-    curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p'
+    tag="$(curl -fsSLI -o /dev/null -w '%{url_effective}' "https://github.com/${REPO}/releases/latest" 2>/dev/null | sed -n 's#.*/releases/tag/##p')"
   elif command -v wget >/dev/null 2>&1; then
-    wget -qO- "https://api.github.com/repos/${REPO}/releases/latest" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p'
+    tag="$(wget -S --spider "https://github.com/${REPO}/releases/latest" 2>&1 | sed -n 's#.*/releases/tag/##p' | tr -d '\r' | sed 's/ .*//' | tail -n1)"
+  fi
+
+  if [ -n "$tag" ]; then
+    echo "$tag"
+    return 0
+  fi
+
+  # FALLBACK: api.github.com (rate-limited unless GITHUB_TOKEN is set).
+  if command -v curl >/dev/null 2>&1; then
+    if [ -n "${GITHUB_TOKEN:-}" ]; then
+      curl -fsSL -H "Authorization: Bearer ${GITHUB_TOKEN}" "https://api.github.com/repos/${REPO}/releases/latest" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p'
+    else
+      curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p'
+    fi
+  elif command -v wget >/dev/null 2>&1; then
+    if [ -n "${GITHUB_TOKEN:-}" ]; then
+      wget -qO- --header="Authorization: Bearer ${GITHUB_TOKEN}" "https://api.github.com/repos/${REPO}/releases/latest" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p'
+    else
+      wget -qO- "https://api.github.com/repos/${REPO}/releases/latest" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p'
+    fi
   else
     echo "Error: curl or wget required" >&2
     exit 1


### PR DESCRIPTION
## Bug

`curl -fsSL https://install.bitbadges.io | sh` fails for some users with:

```
Fetching latest release...
curl: (56) The requested URL returned error: 403
Error: could not determine latest release version
```

## Root cause

`get_latest_version()` queried `https://api.github.com/repos/<repo>/releases/latest` **unauthenticated**. GitHub caps anonymous API calls at **60/hour per IP** and returns **HTTP 403** (not 429) once that pool is exhausted. On a shared/NAT'd IP — corporate networks, CI runners, or a box already running `gh` — the quota runs dry, `sed` extracts nothing from the 403 body, and the install aborts.

Confirmed via response headers: `x-ratelimit-limit: 60`, `x-ratelimit-remaining: 0`. The repo and releases were always fine (latest is `v32`).

The `curl: (56)` exit code (rather than the plain `-f` exit 22) is just how curl reports a 403 over HTTP/2 with `--fail` — it does not contradict the rate-limit diagnosis.

## Fix

Rewrite `get_latest_version()`:

- **Primary:** resolve the tag via the github.com **web redirect**. `/releases/latest` 302-redirects to `/releases/tag/<tag>`; read the tag off the final effective URL (`curl -fsSLI -w '%{url_effective}'` / `wget -S --spider` Location). This path **never touches `api.github.com`**, so it is immune to the API rate limit.
- **Fallback:** only if the redirect yields no tag, query the API as before — now sending `Authorization: Bearer $GITHUB_TOKEN` when that env var is set (lifts the limit to 5,000/hr). Both curl and wget branches retained.

Surgical: nothing else in the installer changes (asset naming, install logic, SDK CLI install all untouched).

## Verification

- `sh -n install.sh` — passes.
- Primary resolver returns `v32` and, traced with `curl -v`, contacts **only `github.com`** on the happy path — never `api.github.com`.
- Forced API fallback still parses `tag_name` correctly.
- Confirmed each network call is piped into `sed` so a `-f` failure (exit non-zero) is masked by sed's exit 0 — `set -e` does not abort before the fallback runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)