### PR TITLE
config: 1.5s block time (timeout_commit 250ms → 1500ms)

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -172,3 +172,6 @@ genesis:
 validators:
     - name: alice
       bonded: 1000000000000000ustake
+      config:
+        consensus:
+          timeout_commit: "1500ms"


### PR DESCRIPTION
## What
Bumps validator consensus `timeout_commit` in `config.yml` from `250ms` (sub-second blocks) to `1500ms` for ~1.5s block times.

`timeout_commit` is how long a validator waits after committing a block before starting the next height, so block time ≈ `timeout_commit` + proposal/processing. At 1500ms this yields roughly 1.5s blocks.

## Note
The runtime node home (`~/.bitbadgeschain/config/config.toml`) was updated separately on the dev node — that file is not tracked here. Existing deployed nodes need the same `timeout_commit = "1500ms"` edit (or a fresh init from this config) to pick up the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)