### PR TITLE
perf(tokenization): cut UniversalRemoveOverlaps gas 500->20

### DIFF
--- a/x/tokenization/types/universal_permissions.go
+++ b/x/tokenization/types/universal_permissions.go
@@ -113,7 +113,11 @@ func UniversalRemoveOverlapFromValues(ctx sdk.Context, overlap *UniversalPermiss
 
 func UniversalRemoveOverlaps(ctx sdk.Context, toRemove *UniversalPermissionDetails, base *UniversalPermissionDetails) ([]*UniversalPermissionDetails, []*UniversalPermissionDetails) {
 	if !ctx.IsZero() {
-		ctx.GasMeter().ConsumeGas(500, "UniversalRemoveOverlaps")
+		// Pure in-memory bigint/range arithmetic, no state access. Anchored just
+		// below the SDK's IterNextCostFlat (30) — a store-iterator step does
+		// strictly more work than this. The tx gas limit bounds the O(n*m) call
+		// fan-out; no separate input-length cap is needed.
+		ctx.GasMeter().ConsumeGas(20, "UniversalRemoveOverlaps")
 	}
 
 	toRemove = AddDefaultsIfNil(toRemove)

--- a/x/tokenization/types/universal_permissions_test.go
+++ b/x/tokenization/types/universal_permissions_test.go
@@ -6,9 +6,11 @@ import (
 	"github.com/bitbadges/bitbadgeschain/x/tokenization/types"
 
 	sdkmath "cosmossdk.io/math"
+	storetypes "cosmossdk.io/store/types"
 	"github.com/stretchr/testify/require"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/testutil"
 )
 
 const (
@@ -837,4 +839,36 @@ func TestRemoveAddresses(t *testing.T) {
 	}
 
 	require.Equal(t, expected, remaining)
+}
+
+// Pins the metered cost of UniversalRemoveOverlaps. The function is the
+// per-iteration body of the O(n*m) overlap algorithm, so this constant is
+// multiplied across every pair compared in a permission update — a regression
+// here is a chain-wide fee/throughput change, not a local detail.
+func TestRemoveOverlapsGasCost(t *testing.T) {
+	key := storetypes.NewKVStoreKey("test")
+	tkey := storetypes.NewTransientStoreKey("transient_test")
+	ctx := testutil.DefaultContext(key, tkey).
+		WithGasMeter(storetypes.NewGasMeter(1_000_000))
+
+	a := &types.UniversalPermissionDetails{
+		TokenId: &types.UintRange{Start: sdkmath.NewUint(1), End: sdkmath.NewUint(10)},
+	}
+	b := &types.UniversalPermissionDetails{
+		TokenId: &types.UintRange{Start: sdkmath.NewUint(5), End: sdkmath.NewUint(15)},
+	}
+
+	before := ctx.GasMeter().GasConsumed()
+	types.UniversalRemoveOverlaps(ctx, a, b)
+	require.Equal(t, uint64(20), ctx.GasMeter().GasConsumed()-before,
+		"one call must charge exactly 20 gas")
+
+	// A second call charges exactly one more increment (no hidden double-billing).
+	before = ctx.GasMeter().GasConsumed()
+	types.UniversalRemoveOverlaps(ctx, a, b)
+	require.Equal(t, uint64(20), ctx.GasMeter().GasConsumed()-before)
+
+	// Zero context (no multistore) must skip the charge entirely.
+	r, _ := types.UniversalRemoveOverlaps(sdk.Context{}, a, b)
+	require.NotNil(t, r)
 }


### PR DESCRIPTION
## What

Recalibrate the gas charged by `UniversalRemoveOverlaps` (`x/tokenization/types/universal_permissions.go`) from **500 → 20** per call.

## Why

The 500-gas charge was an arbitrary placeholder with no grounding. The function is **pure in-memory bigint/range arithmetic with zero state access** (`RemoveUintRangeFromUintRange` + `RemoveAddressListFromAddressList`), yet it's the per-iteration body of the `O(n*m)` overlap algorithm in `GetOverlapsAndNonOverlaps`. So the real cost was `500 * n * m` — a 20×20 permission diff burned ~200k gas of pure arithmetic, equivalent to ~100 state writes that never happen. That needlessly bottlenecks permission updates.

## Calibration

Anchored against the Cosmos SDK / `cosmossdk.io/store` gas schedule:

| Operation | Gas | Touches state? |
|---|---|---|
| KVStore read (`Get`) | 1000 | yes |
| KVStore write (`Set`) | 2000 | yes |
| **Iterator step (`IterNextCostFlat`)** | **30** | yes |
| `UniversalRemoveOverlaps` (this) | **20** | **no** |

A store-iterator step (30) does strictly *more* work than this pure arithmetic, so 20 sits just below it — defensible and not under-priced (the bigint ops aren't free). ~25× cheaper.

## No input-length cap

Deliberately not added. In a gas-metered `Msg` handler the **tx gas limit is the bound**: every call burns 20, so an oversized diff simply runs out of gas and aborts. The `!ctx.IsZero()` guard still skips the charge in simulate/test contexts.

## Tests

`TestRemoveOverlapsGasCost` pins the per-call charge to exactly **20**, asserts a second call adds exactly one more increment (no hidden double-billing), and confirms the zero-context guard skips the charge. A regression here is a chain-wide fee/throughput change, so it's worth pinning.

Verified: `go test -tags=test ./x/tokenization/types/` passes (full package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)