### PR TITLE
fix(tokenization): stop panicking on approvals with no criteria

### DIFF
--- a/x/tokenization/keeper/approval_comparison.go
+++ b/x/tokenization/keeper/approval_comparison.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"bytes"
+	"reflect"
 
 	"github.com/bitbadges/bitbadgeschain/x/tokenization/types"
 	"github.com/gogo/protobuf/proto"
@@ -20,17 +21,43 @@ func compareUintRanges(a, b []*types.UintRange) bool {
 	return true
 }
 
+// criteriaIsAbsent reports whether m carries no criteria at all.
+//
+// A plain `m == nil` is not enough and this is not a hypothetical: it panicked
+// on mainnet. approvalCriteria is optional, so an approval that restricts
+// nothing holds a nil *ApprovalCriteria. Assigning that to a proto.Message
+// parameter produces an interface that is NOT nil — it is
+// (type=*ApprovalCriteria, value=nil) — so `m == nil` is false, and
+// proto.Marshal then calls MarshalToSizedBuffer on a nil receiver and
+// dereferences it:
+//
+//	panic recovered in runTx err="recovered: runtime error: invalid memory
+//	address or nil pointer dereference"
+//	(*ApprovalCriteria).MarshalToSizedBuffer(0x0, ...)
+//
+// The interface cannot be avoided here — three distinct criteria types
+// (ApprovalCriteria, OutgoingApprovalCriteria, IncomingApprovalCriteria) share
+// this helper — so the nil has to be unwrapped by reflection instead.
+func criteriaIsAbsent(m proto.Message) bool {
+	if m == nil {
+		return true
+	}
+	v := reflect.ValueOf(m)
+	return v.Kind() == reflect.Ptr && v.IsNil()
+}
+
 // compareApprovalCriteria compares two protobuf messages for equality using
 // canonical binary marshaling. proto.MarshalTextString is not deterministic
 // across gogo/protobuf versions (whitespace, field ordering), so binary Marshal
 // is used instead — it is the same encoding used for consensus state and is
 // stable across nodes.
 func compareApprovalCriteria(a, b proto.Message) bool {
-	if (a == nil) != (b == nil) {
-		return false
-	}
-	if a == nil && b == nil {
-		return true
+	aAbsent, bAbsent := criteriaIsAbsent(a), criteriaIsAbsent(b)
+	if aAbsent || bAbsent {
+		// Absent on both sides is equal; absent on one side is not. An absent
+		// criteria and a present-but-empty one are different states on the
+		// wire, and changing between them is a real change to the approval.
+		return aAbsent && bAbsent
 	}
 	aBytes, errA := proto.Marshal(a)
 	bBytes, errB := proto.Marshal(b)

--- a/x/tokenization/keeper/approval_comparison_nil_test.go
+++ b/x/tokenization/keeper/approval_comparison_nil_test.go
@@ -1,0 +1,71 @@
+package keeper
+
+import (
+	"testing"
+
+	"github.com/bitbadges/bitbadgeschain/x/tokenization/types"
+)
+
+// TestCompareApprovalCriteriaHandlesAbsentCriteria reproduces a panic seen on
+// mainnet (v33, cosmos-sdk v0.53.6) while simulating MsgUniversalUpdateCollection:
+//
+//	panic recovered in runTx err="recovered: runtime error: invalid memory
+//	address or nil pointer dereference"
+//	(*ApprovalCriteria).MarshalToSizedBuffer(0x0, ...)
+//	gogo/protobuf/proto.Marshal({0x5c4f110, 0x0})
+//	keeper.compareApprovalCriteria(...) approval_comparison.go:35
+//
+// approvalCriteria is an optional field, so an approval that does not restrict
+// transfers carries a nil pointer. compareApprovalCriteria takes proto.Message,
+// and a nil *ApprovalCriteria stored in an interface is NOT an interface nil —
+// it is (type=*ApprovalCriteria, value=nil). So both nil guards fall through
+// and proto.Marshal dereferences the nil receiver.
+//
+// Each subtest passes a typed nil the way the three real call sites do
+// (collectionApprovalEqual, userOutgoingApprovalEqual, userIncomingApprovalEqual),
+// because the bug lives in the conversion to the interface, not in the values.
+func TestCompareApprovalCriteriaHandlesAbsentCriteria(t *testing.T) {
+	t.Run("collection", func(t *testing.T) {
+		var absent *types.ApprovalCriteria
+		if !compareApprovalCriteria(absent, absent) {
+			t.Fatal("two absent collection criteria must compare equal")
+		}
+		if compareApprovalCriteria(absent, &types.ApprovalCriteria{}) {
+			t.Fatal("an absent criteria must not equal a present empty one")
+		}
+	})
+
+	t.Run("outgoing", func(t *testing.T) {
+		var absent *types.OutgoingApprovalCriteria
+		if !compareApprovalCriteria(absent, absent) {
+			t.Fatal("two absent outgoing criteria must compare equal")
+		}
+	})
+
+	t.Run("incoming", func(t *testing.T) {
+		var absent *types.IncomingApprovalCriteria
+		if !compareApprovalCriteria(absent, absent) {
+			t.Fatal("two absent incoming criteria must compare equal")
+		}
+	})
+}
+
+// TestCollectionApprovalEqualWithAbsentCriteria drives the real call site rather
+// than the helper, which is the path MsgUniversalUpdateCollection takes when it
+// compares a submitted approval against the stored one to decide whether the
+// version changed.
+func TestCollectionApprovalEqualWithAbsentCriteria(t *testing.T) {
+	approval := func() *types.CollectionApproval {
+		return &types.CollectionApproval{
+			ApprovalId:        "unrestricted",
+			FromListId:        "All",
+			ToListId:          "All",
+			InitiatedByListId: "All",
+			ApprovalCriteria:  nil,
+		}
+	}
+
+	if !collectionApprovalEqual(approval(), approval()) {
+		t.Fatal("an approval with no criteria must equal itself; a panic here is the mainnet bug")
+	}
+}


### PR DESCRIPTION
Fixes a nil-pointer panic hit on mainnet (v33) while simulating
`MsgUniversalUpdateCollection`. Found in the live chain logs, reproduced in a
unit test, then fixed.

## The bug

`approvalCriteria` is optional, so an approval that restricts nothing carries a
nil pointer. `compareApprovalCriteria` guards with `a == nil`:

```go
func compareApprovalCriteria(a, b proto.Message) bool {
	if (a == nil) != (b == nil) { return false }
	if a == nil && b == nil     { return true }
	aBytes, errA := proto.Marshal(a)   // panics
```

That guard looks correct and is not. A nil `*ApprovalCriteria` assigned to a
`proto.Message` parameter produces an interface that is **not** nil — it is
`(type=*ApprovalCriteria, value=nil)`. Both guards fall through and
`proto.Marshal` dereferences the nil receiver.

The mainnet stack says it precisely:

```
proto.Marshal({0x5c4f110, 0x0})                 type ptr set, value nil
(*ApprovalCriteria).MarshalToSizedBuffer(0x0)   nil receiver
```

## Why the fix looks like this

The interface cannot be dropped: three distinct types share this helper
(`ApprovalCriteria`, `OutgoingApprovalCriteria`, `IncomingApprovalCriteria`),
which is *why* it takes `proto.Message`. Generics do not help — a typed nil
still satisfies the constraint and still panics. Nil-checking at the three call
sites would work until someone adds a fourth.

So the nil is unwrapped by reflection at the single choke point.

Absent and present-but-empty are deliberately **not** collapsed: they are
different states on the wire, and this helper decides whether an approval's
version changed.

## Severity

Not a chain halt. `runTx` recovery catches it, the node keeps running, and only
the transaction fails. Deterministic across nodes, so never a consensus risk.
The user-visible effect is that affected collections cannot be updated and the
error surfaces as a raw nil dereference.

Observed 3 times in 30 days on mainnet, 2 of them in the last 24 hours.

## Audit for the same pattern

| site | verdict |
|---|---|
| `approval_comparison.go` | the bug — fixed here |
| `balance_utils.go:22` | safe — nil-checks the concrete pointer, which works |
| `gamm/precompile.go:507,518` | latent — `resp.(proto.Message)` would panic on a typed-nil response |
| rest of the tree | only one other function takes a proto interface |

The gamm sites are **not reachable today**: they need a query handler that
returns a typed-nil response with a nil error, and none of the four
`return nil, nil` sites in `x/` are gamm query handlers. Worth a follow-up
ticket rather than widening this diff.

## Testing

`approval_comparison_nil_test.go` reproduces the mainnet panic before the fix
and covers all three criteria types plus the real `collectionApprovalEqual`
call path. Full suite green: 76 packages, 0 failures.
