### PR TITLE
ci: skip Build & test while cosmos/evm points at the private hotfix repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,37 @@ env:
   GO_TEST_TIMEOUT: 30m
 
 jobs:
+  # While go.mod redirects cosmos/evm to the embargoed hotfix repo, the runner
+  # has no credentials for that private module and resolution fails before
+  # anything compiles. That made `Build & test` red on master and on every PR
+  # opened against it, so a red check stopped carrying any information about
+  # the change under review.
+  #
+  # release.yml already gates on this. Mirroring it here turns the wall of red
+  # into a deliberate skip, and keeps the gate honest the moment the public
+  # tag lands and the replace comes out.
+  preflight:
+    name: Can CI build this commit?
+    runs-on: ubuntu-latest
+    outputs:
+      can_build: ${{ steps.check.outputs.can_build }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: check
+        run: |
+          if grep -qE '^\s*replace\s+github\.com/cosmos/evm\s+=>' go.mod; then
+            echo "go.mod redirects cosmos/evm to a private module; CI cannot build it." >&2
+            grep -E '^\s*replace\s+github\.com/cosmos/evm\s+=>' go.mod >&2
+            echo "Verify locally with: go test ./... -count=1 -tags=test" >&2
+            echo "can_build=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "can_build=true" >> "$GITHUB_OUTPUT"
+          fi
+
   build:
     name: Build & test
+    needs: preflight
+    if: needs.preflight.outputs.can_build == 'true'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Refs [BB-31](https://linear.app/bitbadges/issue/BB-31/chain-ci-build-and-test-is-red-on-master-until-the-cosmosevm-hotfix).

## Problem

`go.mod` redirects `cosmos/evm` to the embargoed August 2026 hotfix repo:

```
replace github.com/cosmos/evm => github.com/cosmos/evm-ghsa-aug-2026 v0.7.3-august-2026-hotfix
```

Actions has no credentials for that private module, so resolution fails before
anything compiles. `Build & test` has been red on `master` and on every PR
opened against it since v34. CodeQL and Snyk still pass, so PRs show a mixed
board and the red check reads as noise rather than as a signal about the change.

## Change

`release.yml` has gated on exactly this since the hotfix shipped. `build.yml`
gets the same `preflight` job, so the result is an explicit skip instead of a
wall of red.

The gate greps `go.mod` on every run. The day the public tag lands and the
`replace` comes out, `Build & test` starts running again with no workflow edit.

## Not fixed here

The underlying blocker is upstream. Latest public `cosmos/evm` tags are still
`v0.7.2` / `v0.6.2` — no `v0.7.3` carrying the fix. BB-31 stays open until that
publishes, the `replace` drops, and `Build & test` is confirmed green *and
actually run* on `master`.

## Verification

- YAML parses; `jobs: [preflight, build]`, `build` has `needs: preflight` and the `if` guard.
- Gate logic exercised both ways: with the current `go.mod` (replace present) it emits `can_build=false`; against a `go.mod` without the replace it emits `can_build=true`.
- No Go code touched, so the local suite is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMRP24oQWH7TRPpW7cADD9