### PR TITLE
fix(poolmanager): community-pool swap denom to ubadge + wire params gov route

### DIFF
--- a/app/gov_param_change_route_test.go
+++ b/app/gov_param_change_route_test.go
@@ -1,0 +1,26 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	paramproposal "github.com/cosmos/cosmos-sdk/x/params/types/proposal"
+)
+
+// TestLegacyGovRouterRoutesParamChangeProposals pins the gov legacy-content
+// router wiring. Subspace-backed modules (poolmanager, gamm, ...) have no
+// MsgUpdateParams, so a legacy ParameterChangeProposal (wrapped in
+// MsgExecLegacyContent) is the ONLY governance path that can change their
+// params. Without the params route, gov rejects such proposals at submission
+// with "no handler exists for proposal type".
+func TestLegacyGovRouterRoutesParamChangeProposals(t *testing.T) {
+	app := Setup(false)
+	router := app.GovKeeper.LegacyRouter()
+
+	require.True(t, router.HasRoute(paramproposal.RouterKey),
+		"legacy gov router must route %q (ParameterChangeProposal)", paramproposal.RouterKey)
+	require.True(t, router.HasRoute(govtypes.RouterKey),
+		"legacy gov router must keep the base gov route")
+}

--- a/app/ibc.go
+++ b/app/ibc.go
@@ -10,6 +10,8 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	govv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
+	"github.com/cosmos/cosmos-sdk/x/params"
+	paramproposal "github.com/cosmos/cosmos-sdk/x/params/types/proposal"
 	transferkeeper "github.com/cosmos/ibc-go/v11/modules/apps/transfer/keeper"
 	icamodule "github.com/cosmos/ibc-go/v11/modules/apps/27-interchain-accounts"
 	icacontroller "github.com/cosmos/ibc-go/v11/modules/apps/27-interchain-accounts/controller"
@@ -161,6 +163,11 @@ func (app *App) registerIBCModules(appOpts servertypes.AppOptions) error {
 	// See: https://docs.cosmos.network/main/modules/gov#proposal-messages
 	govRouter := govv1beta1.NewRouter()
 	govRouter.AddRoute(govtypes.RouterKey, govv1beta1.ProposalHandler)
+	// Route legacy ParameterChangeProposal content (submitted via
+	// MsgExecLegacyContent) to the x/params keeper. Needed for gov-driven
+	// updates of subspace-backed params (e.g. poolmanager), which have no
+	// MsgUpdateParams of their own.
+	govRouter.AddRoute(paramproposal.RouterKey, params.NewParamChangeProposalHandler(app.ParamsKeeper))
 
 	// Create IBC-Go transfer keeper. IBC v11 dropped the ICS4Wrapper argument
 	// (set later via WithICS4Wrapper) and returns a pointer.

--- a/x/poolmanager/types/params.go
+++ b/x/poolmanager/types/params.go
@@ -61,7 +61,16 @@ func DefaultParams() Params {
 				CommunityPool:  osmomath.MustNewDecFromStr("0.33"), // 33%
 			},
 			AdminAddresses: []string{},
-			CommunityPoolDenomToSwapNonWhitelistedAssetsTo: "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858", // USDC
+			// Stage 1 of a two-stage plan: use native ubadge (deep native
+			// liquidity, always exists) as the community-pool swap target. The
+			// previous value was Osmosis's USDC IBC denom inherited from the
+			// upstream fork, which has zero supply on BitBadges. Stage 2:
+			// switch to canonical USDC
+			// (ibc/E1116484B327AEE59CDC3DA73D319834781A13DB2A7DFC1F38A30CD45ABF58B8)
+			// via governance once a ubadge/USDC pool exists. Note: no non-test
+			// code reads this param today (the epoch community-pool swap path
+			// was not ported), so this value is inert until that path exists.
+			CommunityPoolDenomToSwapNonWhitelistedAssetsTo: "ubadge",
 			ReducedFeeWhitelist:                            []string{},
 			CommunityPoolDenomWhitelist:                    []string{},
 		},

--- a/x/poolmanager/types/params_test.go
+++ b/x/poolmanager/types/params_test.go
@@ -1,0 +1,25 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bitbadges/bitbadgeschain/x/poolmanager/types"
+)
+
+// TestDefaultParamsCommunityPoolSwapDenom pins the default community-pool swap
+// denom so any future change to it is a conscious decision. Stage 1 of the
+// two-stage plan is native ubadge; stage 2 (via governance) is canonical USDC
+// once a ubadge/USDC pool exists. See DefaultParams for the rationale.
+func TestDefaultParamsCommunityPoolSwapDenom(t *testing.T) {
+	params := types.DefaultParams()
+	require.Equal(t, "ubadge",
+		params.TakerFeeParams.CommunityPoolDenomToSwapNonWhitelistedAssetsTo)
+}
+
+// TestDefaultParamsValidate ensures the shipped defaults always pass their own
+// validation.
+func TestDefaultParamsValidate(t *testing.T) {
+	require.NoError(t, types.DefaultParams().Validate())
+}


### PR DESCRIPTION
## What

Two related governance-hygiene fixes (BB-22):

1. **`x/poolmanager`: default community-pool swap denom → `ubadge`.**
   `DefaultParams()` pinned Osmosis's USDC IBC denom
   (`ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858`),
   inherited from the upstream fork and with **zero supply on BitBadges**.
   Stage 1 of a two-stage plan: native `ubadge` now (always exists, native
   liquidity); stage 2 switches to canonical USDC
   (`ibc/E1116484B327AEE59CDC3DA73D319834781A13DB2A7DFC1F38A30CD45ABF58B8`)
   via governance once a ubadge/USDC pool exists. A new test pins the default
   so any future change is a conscious one.

2. **`app`: register the params gov route.** While preparing the matching
   mainnet proposal, validation showed the legacy gov content router only
   routes base gov text proposals — a `ParameterChangeProposal` (via
   `MsgExecLegacyContent`) is rejected at submission with "no handler exists
   for proposal type". Since subspace-backed modules (poolmanager, gamm, …)
   have no `MsgUpdateParams`, that made their params ungovernable on a live
   chain. This wires the standard
   `params.NewParamChangeProposalHandler(app.ParamsKeeper)` route, pinned by
   an app test.

## No-live-reader status

No non-test Go reads `CommunityPoolDenomToSwapNonWhitelistedAssetsTo` today —
the Osmosis epoch community-pool swap path was not ported. The default-value
change is inert until that path ever exists; the router fix is what makes the
mainnet param change (drafted as
`bitbadges-autopilot/outputs/gov/bb22-community-pool-denom-proposal.json`)
submittable after the next upgrade.

## Testing

- `GOTOOLCHAIN=go1.26.6 go test ./... -tags=test` — full suite green locally
  (CI's Build & test is red repo-wide from the embargoed `cosmos/evm` replace;
  verified locally per the standing note).
- New: `TestDefaultParamsCommunityPoolSwapDenom`,
  `TestDefaultParamsValidate` (x/poolmanager/types),
  `TestLegacyGovRouterRoutesParamChangeProposals` (app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xNPHjLACbxiwG9gTZTo5h


## Linear
Part of BB-22 (gov proposal submits after the next upgrade ships this)
